### PR TITLE
fix: implement Copilot PR review suggestions

### DIFF
--- a/src/app/(player)/join/page.tsx
+++ b/src/app/(player)/join/page.tsx
@@ -3,7 +3,7 @@ import { PlayerJoinForm } from '@/components/player/player-join-form';
 
 export default function PlayerJoinPage() {
   return (
-    <Suspense>
+    <Suspense fallback={<div>Loading...</div>}>
       <PlayerJoinForm />
     </Suspense>
   );

--- a/src/app/api/admin/audit/route.ts
+++ b/src/app/api/admin/audit/route.ts
@@ -1,12 +1,35 @@
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
 import { getServices } from '@application/services/factories';
+import {
+  createServerClient,
+  isAdminUser,
+} from '@infrastructure/auth/supabase-auth-client';
 
 export async function GET(request: Request) {
   try {
+    const cookieStore = await cookies();
+    const supabase = await createServerClient(cookieStore);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user || !isAdminUser(user.email)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
     const { searchParams } = new URL(request.url);
     const quizId = searchParams.get('quizId') ?? undefined;
     const limitParam = searchParams.get('limit');
-    const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+    const parsedLimit =
+      limitParam != null ? Number.parseInt(limitParam, 10) : undefined;
+    const limit =
+      parsedLimit != null &&
+      Number.isFinite(parsedLimit) &&
+      Number.isInteger(parsedLimit) &&
+      parsedLimit > 0
+        ? parsedLimit
+        : undefined;
 
     const { auditService } = getServices();
     const logs = await auditService.listAuditLogs({ quizId, limit });

--- a/src/app/api/admin/questions/route.ts
+++ b/src/app/api/admin/questions/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
 import { getServices } from '@application/services/factories';
+import {
+  createServerClient,
+  isAdminUser,
+} from '@infrastructure/auth/supabase-auth-client';
 
 /**
  * GET /api/admin/questions
@@ -7,6 +12,16 @@ import { getServices } from '@application/services/factories';
  */
 export async function GET(request: Request) {
   try {
+    const cookieStore = await cookies();
+    const supabase = await createServerClient(cookieStore);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user || !isAdminUser(user.email)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
     const { searchParams } = new URL(request.url);
     const quizId = searchParams.get('quizId') ?? undefined;
     const type = searchParams.get('type') ?? undefined;

--- a/src/application/dtos/audit-log.dto.ts
+++ b/src/application/dtos/audit-log.dto.ts
@@ -1,8 +1,12 @@
-export interface AuditLogDTO {
-  id: string;
-  quizId?: string;
-  eventType: string;
-  summary: string;
-  metadata: Record<string, unknown>;
-  createdAt: string;
-}
+import { z } from 'zod';
+
+export const AuditLogDTO = z.object({
+  id: z.string(),
+  quizId: z.string().optional(),
+  eventType: z.string(),
+  summary: z.string(),
+  metadata: z.record(z.unknown()),
+  createdAt: z.string(),
+});
+
+export type AuditLogDTO = z.infer<typeof AuditLogDTO>;

--- a/src/application/dtos/audit-log.dto.ts
+++ b/src/application/dtos/audit-log.dto.ts
@@ -5,7 +5,7 @@ export const AuditLogDTO = z.object({
   quizId: z.string().optional(),
   eventType: z.string(),
   summary: z.string(),
-  metadata: z.record(z.unknown()),
+  metadata: z.record(z.string(), z.unknown()),
   createdAt: z.string(),
 });
 

--- a/src/application/use-cases/advance-question.use-case.ts
+++ b/src/application/use-cases/advance-question.use-case.ts
@@ -36,15 +36,22 @@ export class AdvanceQuestionUseCase {
     await this.quizRepository.save(quizAggregate);
 
     if (this.auditLogRepository) {
-      void this.auditLogRepository.save(
-        new AuditLog(randomUUID(), AuditEventType.QuestionAdvanced, {
-          quizId,
-          metadata: {
-            questionIndex: quizAggregate.currentQuestionIndex,
-            questionId: nextQuestion?.id ?? null,
-          },
-        })
-      );
+      void this.auditLogRepository
+        .save(
+          new AuditLog(randomUUID(), AuditEventType.QuestionAdvanced, {
+            quizId,
+            metadata: {
+              questionIndex: quizAggregate.currentQuestionIndex,
+              questionId: nextQuestion?.id ?? null,
+            },
+          })
+        )
+        .catch((error) => {
+          console.error(
+            'Failed to save audit log for AdvanceQuestionUseCase',
+            error
+          );
+        });
     }
 
     return {

--- a/src/application/use-cases/create-quiz.use-case.ts
+++ b/src/application/use-cases/create-quiz.use-case.ts
@@ -30,12 +30,19 @@ export class CreateQuizUseCase {
     const savedQuiz = await this.quizRepository.create(quiz);
 
     if (this.auditLogRepository) {
-      void this.auditLogRepository.save(
-        new AuditLog(randomUUID(), AuditEventType.QuizCreated, {
-          quizId: savedQuiz.id,
-          metadata: { title: data.title },
-        })
-      );
+      void this.auditLogRepository
+        .save(
+          new AuditLog(randomUUID(), AuditEventType.QuizCreated, {
+            quizId: savedQuiz.id,
+            metadata: { title: data.title },
+          })
+        )
+        .catch((error) => {
+          console.error(
+            'Failed to save audit log for CreateQuizUseCase',
+            error
+          );
+        });
     }
 
     return savedQuiz.id;

--- a/src/application/use-cases/list-all-questions.use-case.ts
+++ b/src/application/use-cases/list-all-questions.use-case.ts
@@ -18,10 +18,17 @@ export class ListAllQuestionsUseCase {
       ? [await this.quizRepo.findEntityById(quizId)].filter(Boolean)
       : await this.quizRepo.findAll();
 
+    const quizList = quizzes as NonNullable<(typeof quizzes)[number]>[];
+
+    const questionsByQuiz = await Promise.all(
+      quizList.map((quiz) => this.questionRepo.listByQuizId(quiz.id))
+    );
+
     const results: QuestionListItemDTO[] = [];
 
-    for (const quiz of quizzes as NonNullable<(typeof quizzes)[number]>[]) {
-      const questions = await this.questionRepo.listByQuizId(quiz.id);
+    for (let i = 0; i < quizList.length; i++) {
+      const quiz = quizList[i];
+      const questions = questionsByQuiz[i];
       for (const q of questions) {
         if (type && q.type !== type) continue;
         results.push({

--- a/src/application/use-cases/lock-question.use-case.ts
+++ b/src/application/use-cases/lock-question.use-case.ts
@@ -71,15 +71,22 @@ export class LockQuestionUseCase {
     await this.quizRepository.save(quiz);
 
     if (this.auditLogRepository) {
-      void this.auditLogRepository.save(
-        new AuditLog(randomUUID(), AuditEventType.QuestionLocked, {
-          quizId,
-          metadata: {
-            questionId: currentQuestion.id,
-            questionIndex: quiz.currentQuestionIndex,
-          },
-        })
-      );
+      void this.auditLogRepository
+        .save(
+          new AuditLog(randomUUID(), AuditEventType.QuestionLocked, {
+            quizId,
+            metadata: {
+              questionId: currentQuestion.id,
+              questionIndex: quiz.currentQuestionIndex,
+            },
+          })
+        )
+        .catch((error) => {
+          console.error(
+            'Failed to save audit log for LockQuestionUseCase',
+            error
+          );
+        });
     }
 
     return roundSummary;

--- a/src/application/use-cases/start-quiz.use-case.ts
+++ b/src/application/use-cases/start-quiz.use-case.ts
@@ -20,9 +20,13 @@ export class StartQuizUseCase {
     await this.quizRepository.save(quiz);
 
     if (this.auditLogRepository) {
-      void this.auditLogRepository.save(
-        new AuditLog(randomUUID(), AuditEventType.QuizStarted, { quizId })
-      );
+      void this.auditLogRepository
+        .save(
+          new AuditLog(randomUUID(), AuditEventType.QuizStarted, { quizId })
+        )
+        .catch((error) => {
+          console.error('Failed to save audit log for StartQuizUseCase', error);
+        });
     }
   }
 }

--- a/src/components/admin/all-questions-view.tsx
+++ b/src/components/admin/all-questions-view.tsx
@@ -171,9 +171,9 @@ export function AllQuestionsView() {
         </div>
       )}
 
-      {editingQuestion && (
+      {editingQuestion && editingQuestion.quizId && (
         <EditQuestionDialog
-          quizId={editingQuestion.quizId!}
+          quizId={editingQuestion.quizId}
           question={editingQuestion}
           open={!!editingQuestion}
           onOpenChange={(open) => {
@@ -185,9 +185,9 @@ export function AllQuestionsView() {
         />
       )}
 
-      {deletingQuestion && (
+      {deletingQuestion && deletingQuestion.quizId && (
         <DeleteQuestionDialog
-          quizId={deletingQuestion.quizId!}
+          quizId={deletingQuestion.quizId}
           question={deletingQuestion}
           open={!!deletingQuestion}
           onOpenChange={(open) => {

--- a/src/components/admin/audit-log-table.tsx
+++ b/src/components/admin/audit-log-table.tsx
@@ -38,7 +38,9 @@ function formatDate(iso: string) {
 export function AuditLogTable() {
   const [selectedQuizId, setSelectedQuizId] = useState<string>('all');
 
-  const { data: quizzes = [] } = useQuery<QuizListItemDTO[]>({
+  const { data: quizzes = [], error: quizzesError } = useQuery<
+    QuizListItemDTO[]
+  >({
     queryKey: ['admin', 'quizzes'],
     queryFn: async () => {
       const res = await fetch('/api/admin/quizzes');
@@ -48,7 +50,11 @@ export function AuditLogTable() {
     staleTime: 30_000,
   });
 
-  const { data: logs = [], isLoading } = useQuery<AuditLogDTO[]>({
+  const {
+    data: logs = [],
+    isLoading,
+    error: logsError,
+  } = useQuery<AuditLogDTO[]>({
     queryKey: ['admin', 'audit', selectedQuizId],
     queryFn: async () => {
       const params = new URLSearchParams();
@@ -59,6 +65,17 @@ export function AuditLogTable() {
     },
     staleTime: 10_000,
   });
+
+  if (quizzesError || logsError) {
+    return (
+      <div className="text-center py-8 text-sm text-destructive">
+        {quizzesError
+          ? 'Failed to load quizzes.'
+          : 'Failed to load audit logs.'}{' '}
+        Please try again.
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/src/components/admin/media-library.tsx
+++ b/src/components/admin/media-library.tsx
@@ -3,11 +3,11 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Trash2 } from 'lucide-react';
 import { Button } from '@ui/button';
-import { SupabaseStorageService } from '@infrastructure/storage/supabase-storage';
+import { createStorageService } from '@infrastructure/storage/supabase-storage';
 import { formatFileSize } from '@lib/image-utils';
 import type { MediaFileDTO } from '@application/dtos/media.dto';
 
-const storageService = new SupabaseStorageService();
+const storageService = createStorageService();
 const BUCKET = 'quiz-media';
 
 export function MediaLibrary() {

--- a/src/infrastructure/storage/supabase-storage.ts
+++ b/src/infrastructure/storage/supabase-storage.ts
@@ -27,7 +27,8 @@ export class SupabaseStorageService implements IStorageService {
     const randomStr = Math.random().toString(36).substring(2, 15);
     const extension = file.name.split('.').pop();
     const filename = `${timestamp}-${randomStr}.${extension}`;
-    const fullPath = path ? `${path}${filename}` : filename;
+    const normalizedPath = path ? (path.endsWith('/') ? path : `${path}/`) : '';
+    const fullPath = normalizedPath ? `${normalizedPath}${filename}` : filename;
 
     // Upload file
     const { data, error } = await this.client.storage
@@ -92,7 +93,9 @@ export class SupabaseStorageService implements IStorageService {
       .filter((f) => f.name !== '.emptyFolderPlaceholder')
       .map((f) => ({
         name: f.name,
-        path: path ? `${path}${f.name}` : f.name,
+        path: path
+          ? `${path.endsWith('/') ? path : path + '/'}${f.name}`
+          : f.name,
         size: f.metadata?.size ?? 0,
         createdAt: f.created_at ?? new Date().toISOString(),
       }));

--- a/src/tests/application/use-cases/advance-question-use-case.test.ts
+++ b/src/tests/application/use-cases/advance-question-use-case.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
 import { AdvanceQuestionUseCase } from '@application/use-cases/advance-question.use-case';
 import { IQuizRepository } from '@domain/repositories/quiz-repository';
+import type { IAuditLogRepository } from '@domain/repositories/audit-log-repository';
+import { AuditEventType } from '@domain/entities/audit-log';
 import { Quiz } from '@domain/entities/quiz';
 import { QuizSessionAggregate } from '@domain/aggregates/quiz-session-aggregate';
 import { Question } from '@domain/entities/question';
@@ -101,5 +103,80 @@ describe('AdvanceQuestionUseCase', () => {
     await expect(useCase.execute('missing')).rejects.toThrow(
       'Quiz with ID missing not found.'
     );
+  });
+
+  it('emits QuestionAdvanced audit log when audit repository is provided', async () => {
+    const auditLogRepository: Mocked<IAuditLogRepository> = {
+      save: vi.fn().mockResolvedValue(undefined),
+      findByQuizId: vi.fn(),
+      findRecent: vi.fn(),
+    };
+
+    const quiz = new Quiz(
+      'quiz-1',
+      'Test',
+      [
+        new Question(
+          'q-1',
+          'Q1',
+          ['A'],
+          'multiple-choice',
+          10,
+          undefined,
+          undefined,
+          ['A', 'B']
+        ),
+        new Question(
+          'q-2',
+          'Q2',
+          ['B'],
+          'multiple-choice',
+          10,
+          undefined,
+          undefined,
+          ['A', 'B']
+        ),
+      ],
+      { allowSkipping: false, timePerQuestion: 30 }
+    );
+    const aggregate = new QuizSessionAggregate(quiz, 30);
+    aggregate.startQuiz();
+    quizRepository.findById.mockResolvedValue(aggregate);
+
+    const useCaseWithAudit = new AdvanceQuestionUseCase(
+      quizRepository,
+      auditLogRepository
+    );
+    await useCaseWithAudit.execute('quiz-1');
+
+    // Allow micro-task to settle so the void promise fires
+    await Promise.resolve();
+    expect(auditLogRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: AuditEventType.QuestionAdvanced })
+    );
+  });
+
+  it('does not throw when audit log save fails', async () => {
+    const auditLogRepository: Mocked<IAuditLogRepository> = {
+      save: vi.fn().mockRejectedValue(new Error('DB error')),
+      findByQuizId: vi.fn(),
+      findRecent: vi.fn(),
+    };
+
+    const quiz = new Quiz(
+      'quiz-1',
+      'Test',
+      [new Question('q-1', 'Q1', ['A'], 'multiple-choice', 10)],
+      { allowSkipping: false, timePerQuestion: 30 }
+    );
+    const aggregate = new QuizSessionAggregate(quiz, 30);
+    aggregate.startQuiz();
+    quizRepository.findById.mockResolvedValue(aggregate);
+
+    const useCaseWithAudit = new AdvanceQuestionUseCase(
+      quizRepository,
+      auditLogRepository
+    );
+    await expect(useCaseWithAudit.execute('quiz-1')).resolves.not.toThrow();
   });
 });

--- a/src/tests/application/use-cases/create-quiz.use-case.test.ts
+++ b/src/tests/application/use-cases/create-quiz.use-case.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mocked } from 'vitest';
 import { IQuizRepository } from '@domain/repositories/quiz-repository';
+import type { IAuditLogRepository } from '@domain/repositories/audit-log-repository';
+import { AuditEventType } from '@domain/entities/audit-log';
 import { CreateQuizUseCase } from '@application/use-cases/create-quiz.use-case';
 import { Quiz } from '@domain/entities/quiz';
 
@@ -85,5 +87,56 @@ describe('CreateQuizUseCase', () => {
     expect(createCall.title).toBe('My Quiz');
     expect(createCall.settings.timePerQuestion).toBe(45);
     expect(createCall.settings.allowSkipping).toBe(true);
+  });
+
+  it('emits QuizCreated audit log when audit repository is provided', async () => {
+    const mockSavedQuiz = { id: 'quiz-123' } as Quiz;
+    vi.spyOn(mockQuizRepository, 'create').mockResolvedValueOnce(mockSavedQuiz);
+
+    const auditLogRepository: Mocked<IAuditLogRepository> = {
+      save: vi.fn().mockResolvedValue(undefined),
+      findByQuizId: vi.fn(),
+      findRecent: vi.fn(),
+    };
+
+    const useCaseWithAudit = new CreateQuizUseCase(
+      mockQuizRepository,
+      auditLogRepository
+    );
+    await useCaseWithAudit.execute({
+      title: 'Audit Quiz',
+      timePerQuestion: 30,
+      allowSkipping: false,
+    });
+
+    await Promise.resolve();
+    expect(auditLogRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: AuditEventType.QuizCreated,
+      })
+    );
+  });
+
+  it('does not throw when audit log save fails', async () => {
+    const mockSavedQuiz = { id: 'quiz-123' } as Quiz;
+    vi.spyOn(mockQuizRepository, 'create').mockResolvedValueOnce(mockSavedQuiz);
+
+    const auditLogRepository: Mocked<IAuditLogRepository> = {
+      save: vi.fn().mockRejectedValue(new Error('DB error')),
+      findByQuizId: vi.fn(),
+      findRecent: vi.fn(),
+    };
+
+    const useCaseWithAudit = new CreateQuizUseCase(
+      mockQuizRepository,
+      auditLogRepository
+    );
+    await expect(
+      useCaseWithAudit.execute({
+        title: 'Audit Quiz',
+        timePerQuestion: 30,
+        allowSkipping: false,
+      })
+    ).resolves.not.toThrow();
   });
 });

--- a/src/tests/application/use-cases/lock-question.use-case.test.ts
+++ b/src/tests/application/use-cases/lock-question.use-case.test.ts
@@ -7,6 +7,8 @@ import { Quiz } from '@domain/entities/quiz';
 import type { ILeaderboardSnapshotRepository } from '@domain/repositories/leaderboard-snapshot-repository';
 import type { IPlayerRepository } from '@domain/repositories/player-repository';
 import type { IQuizRepository } from '@domain/repositories/quiz-repository';
+import type { IAuditLogRepository } from '@domain/repositories/audit-log-repository';
+import { AuditEventType } from '@domain/entities/audit-log';
 import { beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
 
 describe('LockQuestionUseCase', () => {
@@ -276,6 +278,93 @@ describe('LockQuestionUseCase', () => {
       currentRank: 1,
       rankChange: 0,
     });
+  });
+
+  it('emits QuestionLocked audit log when audit repository is provided', async () => {
+    const auditLogRepository: Mocked<IAuditLogRepository> = {
+      save: vi.fn().mockResolvedValue(undefined),
+      findByQuizId: vi.fn(),
+      findRecent: vi.fn(),
+    };
+    const useCaseWithAudit = new LockQuestionUseCase(
+      quizRepository,
+      playerRepository,
+      snapshotRepository,
+      auditLogRepository
+    );
+
+    const question1 = new Question(
+      'q1',
+      'Q?',
+      ['A'],
+      'multiple-choice',
+      100,
+      undefined,
+      undefined,
+      ['A', 'B']
+    );
+    const quiz = new QuizSessionAggregate(
+      new Quiz('quiz-1', 'Test', [question1], {
+        timePerQuestion: 30,
+        allowSkipping: false,
+      }),
+      30
+    );
+    quiz.addPlayer('p1');
+    quiz.startQuiz();
+
+    const player1 = new Player('p1', 'Alice', 'quiz-1');
+    quizRepository.findById.mockResolvedValue(quiz);
+    playerRepository.listByQuizId.mockResolvedValue([player1]);
+    snapshotRepository.findByQuizAndQuestion.mockResolvedValue([]);
+
+    await useCaseWithAudit.execute('quiz-1');
+
+    await Promise.resolve();
+    expect(auditLogRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: AuditEventType.QuestionLocked })
+    );
+  });
+
+  it('does not throw when audit log save fails in lock-question', async () => {
+    const auditLogRepository: Mocked<IAuditLogRepository> = {
+      save: vi.fn().mockRejectedValue(new Error('DB error')),
+      findByQuizId: vi.fn(),
+      findRecent: vi.fn(),
+    };
+    const useCaseWithAudit = new LockQuestionUseCase(
+      quizRepository,
+      playerRepository,
+      snapshotRepository,
+      auditLogRepository
+    );
+
+    const question1 = new Question(
+      'q1',
+      'Q?',
+      ['A'],
+      'multiple-choice',
+      100,
+      undefined,
+      undefined,
+      ['A', 'B']
+    );
+    const quiz = new QuizSessionAggregate(
+      new Quiz('quiz-1', 'Test', [question1], {
+        timePerQuestion: 30,
+        allowSkipping: false,
+      }),
+      30
+    );
+    quiz.addPlayer('p1');
+    quiz.startQuiz();
+
+    const player1 = new Player('p1', 'Alice', 'quiz-1');
+    quizRepository.findById.mockResolvedValue(quiz);
+    playerRepository.listByQuizId.mockResolvedValue([player1]);
+    snapshotRepository.findByQuizAndQuestion.mockResolvedValue([]);
+
+    await expect(useCaseWithAudit.execute('quiz-1')).resolves.not.toThrow();
   });
 
   it('should calculate average time correctly', async () => {

--- a/src/tests/application/use-cases/start-quiz-use-case.test.ts
+++ b/src/tests/application/use-cases/start-quiz-use-case.test.ts
@@ -2,6 +2,8 @@ import { StartQuizUseCase } from '@application/use-cases/start-quiz.use-case';
 import { QuizSessionAggregate } from '@domain/aggregates/quiz-session-aggregate';
 import { Quiz, QuizStatus } from '@domain/entities/quiz';
 import { IQuizRepository } from '@domain/repositories/quiz-repository';
+import type { IAuditLogRepository } from '@domain/repositories/audit-log-repository';
+import { AuditEventType } from '@domain/entities/audit-log';
 import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
 
 describe('StartQuizUseCase', () => {
@@ -47,5 +49,56 @@ describe('StartQuizUseCase', () => {
     );
     expect(quizRepository.findById).toHaveBeenCalledWith('invalidQuizId');
     expect(quizRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('emits QuizStarted audit log when audit repository is provided', async () => {
+    const auditLogRepository: Mocked<IAuditLogRepository> = {
+      save: vi.fn().mockResolvedValue(undefined),
+      findByQuizId: vi.fn(),
+      findRecent: vi.fn(),
+    };
+
+    const quiz = new QuizSessionAggregate(
+      new Quiz('quiz1', 'Sample Quiz', [], {
+        timePerQuestion: 30,
+        allowSkipping: true,
+      }),
+      30
+    );
+    quizRepository.findById.mockResolvedValue(quiz);
+
+    const useCaseWithAudit = new StartQuizUseCase(
+      quizRepository,
+      auditLogRepository
+    );
+    await useCaseWithAudit.execute('quiz1');
+
+    await Promise.resolve();
+    expect(auditLogRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: AuditEventType.QuizStarted })
+    );
+  });
+
+  it('does not throw when audit log save fails', async () => {
+    const auditLogRepository: Mocked<IAuditLogRepository> = {
+      save: vi.fn().mockRejectedValue(new Error('DB error')),
+      findByQuizId: vi.fn(),
+      findRecent: vi.fn(),
+    };
+
+    const quiz = new QuizSessionAggregate(
+      new Quiz('quiz1', 'Sample Quiz', [], {
+        timePerQuestion: 30,
+        allowSkipping: true,
+      }),
+      30
+    );
+    quizRepository.findById.mockResolvedValue(quiz);
+
+    const useCaseWithAudit = new StartQuizUseCase(
+      quizRepository,
+      auditLogRepository
+    );
+    await expect(useCaseWithAudit.execute('quiz1')).resolves.not.toThrow();
   });
 });


### PR DESCRIPTION
- Convert AuditLogDTO from interface to zod schema for runtime validation
- Fix missing path delimiter in supabase-storage upload and listFiles
- Add .catch() handlers to all void audit log saves (advance-question, lock-question, start-quiz, create-quiz) to prevent unhandled rejections
- Fix N+1 query in ListAllQuestionsUseCase using Promise.all
- Add admin auth guard to /api/admin/audit and /api/admin/questions routes
- Fix NaN limit parsing in /api/admin/audit route
- Remove non-null assertions on quizId in AllQuestionsView (guard with conditional rendering)
- Add Suspense fallback in join/page.tsx
- Use createStorageService() factory in MediaLibrary instead of direct instantiation
- Handle query error states in AuditLogTable
- Add unit tests for audit log emission and failure resilience in 4 use cases