### PR TITLE
feat: Player Kick & Auto-Remove

### DIFF
--- a/docs/progress/dev-notes.md
+++ b/docs/progress/dev-notes.md
@@ -1,6 +1,15 @@
 # Dev Progress Log
 
-## 2026-01-31 (R5 Phase 4.2 Connection Health ✅)
+## 2026-05-05 (Player Kick & Auto-Remove ✅)
+- **Soft removal via `Removed` status**: New `PlayerStatus.Removed` in domain + Prisma schema; `removeFromGame(reason)` method on Player entity
+- **RemovePlayerUseCase**: Application use case validates player + quiz ownership, calls domain method, saves. Rejoin support — `Removed` excluded from name-duplicate check in `AddPlayerUseCase`
+- **DELETE API**: `DELETE /api/quiz/[quizId]/player/[playerId]` with optional `reason` body field (defaults to `'kicked'`)
+- **Realtime**: `broadcastPlayerKicked()` sends `player:kicked` event on private `player:{quizId}:{playerId}` channel
+- **Player UI**: `usePlayerSession` listens for `player:kicked` → redirects to `/join?kicked=true`; join page shows amber "You were removed from the game by the host." banner
+- **Host UI**: `useHostQuizPlayers` exposes `kickPlayer(playerId)` + `isKicking`; auto-removes players disconnected >5min via polling loop with `Set` deduplication ref; `PlayerListWithStatus` shows Kick button per row
+- **Verified**: build ✅, lint ✅ (0 errors), 413 tests ✅, manual kick flow ✅
+
+
 - **Connection status monitoring complete**: Hosts can now see player connection health in real-time
 - Created `PresenceMonitor` service with connection thresholds (connected <30s, away 30-120s, disconnected >120s)
 - Built `GetPlayerConnectionStatusUseCase` orchestrating presence detection

--- a/docs/progress/plans/2026-05-05-player-kick-and-auto-remove.md
+++ b/docs/progress/plans/2026-05-05-player-kick-and-auto-remove.md
@@ -1,7 +1,7 @@
 # Player Kick & Auto-Remove
 
 **Date Created:** 2026-05-05
-**Status:** 📋 Planning
+**Status:** ✅ Complete
 **Estimated Time:** ~4.5 hours
 **Branch:** fix/game-lifecycle-ux
 **Depends on:** R6 Phase 3.5 ✅

--- a/docs/progress/plans/2026-05-05-player-kick-and-auto-remove.md
+++ b/docs/progress/plans/2026-05-05-player-kick-and-auto-remove.md
@@ -1,0 +1,330 @@
+# Player Kick & Auto-Remove
+
+**Date Created:** 2026-05-05
+**Status:** 📋 Planning
+**Estimated Time:** ~4.5 hours
+**Branch:** fix/game-lifecycle-ux
+**Depends on:** R6 Phase 3.5 ✅
+
+---
+
+## Overview
+
+Currently, there is no way to remove a player from a quiz once they have joined. If a player disconnects and never comes back, they remain in the lobby/game indefinitely. The host also has no manual control over which players are in the session.
+
+**What is missing:**
+- A `Removed` player status in the domain (currently only `Active | Disconnected | Finished`)
+- A `RemovePlayerUseCase` and corresponding API endpoint (`DELETE /api/quiz/[quizId]/player/[playerId]`)
+- A `player:kicked` realtime event so removed players receive an immediate redirect
+- Auto-removal logic on the host polling hook (5-minute timeout for disconnected players)
+- A "Kick" button in the host player list component
+- Player UI handling for the kicked event (redirect + message)
+- Rejoin support — name duplicate check must skip `Removed` players
+
+**Design decisions confirmed with user:**
+| Decision              | Choice                                                                           |
+| --------------------- | -------------------------------------------------------------------------------- |
+| Auto-remove threshold | 5 minutes (separate from the 120s "disconnected" display threshold)              |
+| Removal type          | Soft delete — new `Removed` status, data kept                                    |
+| Kick scope            | Any time — lobby and during active game                                          |
+| Auto-remove trigger   | Host-side — polling hook detects expired players, calls DELETE                   |
+| Player notification   | Yes — `player:kicked` realtime event redirects their UI                          |
+| Rejoin after kick     | Yes — same join code works; `Removed` players excluded from name duplicate check |
+
+---
+
+## Goals
+
+- [ ] Add `Removed` status to Player domain entity
+- [ ] Create use case and API endpoint to remove a player
+- [ ] Broadcast `player:kicked` realtime event to notify the removed player
+- [ ] Auto-remove players who have been disconnected for 5+ minutes (host polling)
+- [ ] Allow host to manually kick any player with a "Kick" button
+- [ ] Redirect kicked player's UI with an informative message
+- [ ] Allow removed players to rejoin with the same join code
+
+---
+
+## Implementation Steps
+
+### Step 1 — Domain: `Removed` status + `removeFromGame()` method · Small
+
+**Files:** `src/domain/entities/player.ts`, `src/tests/domain/entities/player.test.ts`
+
+- [ ] Add `Removed = 'Removed'` to `PlayerStatus` enum
+- [ ] Add `removeFromGame(reason: 'kicked' | 'timeout'): void` method
+  - Throws if `this.status === PlayerStatus.Removed` (idempotency guard)
+  - Sets `this.status = PlayerStatus.Removed`
+- [ ] Write domain tests:
+  - `removeFromGame('kicked')` from Active → status becomes Removed
+  - `removeFromGame('timeout')` from Disconnected → status becomes Removed
+  - `removeFromGame()` on already-Removed player → throws
+- [ ] Run `yarn test` ✅
+
+---
+
+### Step 2 — Infrastructure: Prisma schema migration · Small
+
+**Files:** `src/infrastructure/database/prisma/schema.prisma`
+
+- [ ] Add `Removed` to `enum PlayerStatus { Active Disconnected Finished Removed }`
+- [ ] Run `yarn prisma:migrate` — name migration `add_removed_player_status`
+- [ ] Run `yarn prisma:generate`
+- [ ] Verify generated client includes `Removed` variant
+- [ ] Run `yarn test` ✅ (existing tests should still pass)
+
+---
+
+### Step 3 — Application: `RemovePlayerUseCase` · Small
+
+**New file:** `src/application/use-cases/remove-player.use-case.ts`
+
+```typescript
+// Input: { playerId: string; quizId: string; reason: 'kicked' | 'timeout' }
+// 1. Find player by playerId — throw 'Player not found' if missing
+// 2. Validate player.quizId === quizId — throw 'Player not found' if mismatch
+// 3. Call player.removeFromGame(reason)
+// 4. Save via playerRepository.save(player)  (or updateStatus equivalent)
+// 5. Return { playerId, quizId, reason }
+```
+
+- [ ] Create `remove-player.use-case.ts` with class `RemovePlayerUseCase`
+- [ ] Add `removePlayer(playerId, quizId, reason)` method to `PlayerService`
+  - File: `src/application/services/player-service.ts`
+  - Instantiates and calls `RemovePlayerUseCase`
+- [ ] Wire `RemovePlayerUseCase` into service factory
+  - File: `src/application/services/factories.ts` (check if explicit wiring is needed)
+- [ ] Write tests in `src/tests/application/use-cases/remove-player.use-case.test.ts`:
+  - Success: `reason: 'kicked'` — player status becomes `Removed`
+  - Success: `reason: 'timeout'` — player status becomes `Removed`
+  - Error: player not found — throws `'Player with ID … not found'`
+  - Error: player belongs to different quiz — throws `'Player not found'`
+  - Error: player already `Removed` — throws (propagated from domain)
+- [ ] Run `yarn test` ✅
+
+---
+
+### Step 4 — Application: Fix name duplicate check for rejoin · Small
+
+**File:** `src/application/use-cases/add-player.use-case.ts`
+
+Currently, when a player tries to join with the same name as an existing player, it throws. A `Removed` player must not count as a name conflict so they can rejoin.
+
+- [ ] Find the duplicate-name check (likely a `listPlayersForQuiz` + filter)
+- [ ] Exclude players with `status === PlayerStatus.Removed` from the name conflict check
+- [ ] Update relevant tests to cover rejoin scenario (removed player name is available again)
+- [ ] Run `yarn test` ✅
+
+---
+
+### Step 5 — Application: Exclude `Removed` from player status list · Small
+
+**Files:** `src/application/use-cases/get-player-connection-status.use-case.ts` (or wherever players are filtered for the host status endpoint)
+
+- [ ] Ensure `Removed` players are **not** returned by `GET /api/quiz/[quizId]/players/status`
+- [ ] Also ensure `GET /api/quiz/[quizId]/players` excludes `Removed` players (or confirm this is already filtered at the repository query level)
+- [ ] Update tests to assert removed players are absent from the list
+- [ ] Run `yarn test` ✅
+
+---
+
+### Step 6 — Realtime: `broadcastPlayerKicked` · Small
+
+**File:** `src/infrastructure/realtime/broadcast-player-events.ts`
+
+- [ ] Add `broadcastPlayerKicked(quizId: string, playerId: string, reason: 'kicked' | 'timeout'): Promise<void>`
+  - Uses channel `player:{quizId}:{playerId}`
+  - Event name: `player:kicked`
+  - Payload: `{ reason: 'kicked' | 'timeout' }`
+- [ ] Run `yarn test` ✅ (no new tests needed — broadcast functions are thin wrappers; covered by integration)
+
+---
+
+### Step 7 — API: `DELETE /api/quiz/[quizId]/player/[playerId]` · Small
+
+**File:** `src/app/api/quiz/[quizId]/player/[playerId]/route.ts`
+
+Add a `DELETE` export to the existing file (which currently only has `GET`):
+
+```typescript
+// Body (optional): { reason?: 'kicked' | 'timeout' }  — defaults to 'kicked'
+// 1. await params; validate quizId + playerId
+// 2. Parse optional body for reason
+// 3. playerService.removePlayer(playerId, quizId, reason)
+// 4. broadcastPlayerKicked(quizId, playerId, reason)
+// 5. return NextResponse.json({ success: true })
+// Errors: 404 if not found, 400 for other errors
+```
+
+- [ ] Add `DeleteBodySchema` zod schema (optional `reason` field, default `'kicked'`)
+- [ ] Implement `DELETE` handler following the standard error-mapping pattern
+- [ ] Run `yarn test` ✅
+
+---
+
+### Step 8 — Player UI: Handle `player:kicked` event · Small
+
+**File:** `src/hooks/use-player-session.ts`
+
+The player private channel already listens for `answer:ack`. Add a handler for the new `player:kicked` event.
+
+- [ ] Import `useRouter` from `next/navigation` (check if already imported)
+- [ ] In the `player:{quizId}:{playerId}` subscription block, add handler:
+  ```typescript
+  channel.on('broadcast', { event: 'player:kicked' }, () => {
+    router.push(`/join/${quizId}?kicked=true`);
+  });
+  ```
+  - Adjust the join URL to match the actual player entry route
+- [ ] Run `yarn test` ✅
+
+---
+
+### Step 9 — Player UI: Kicked message on join page · Small
+
+**File:** Player join/entry page (find the correct page under `src/app/(player)/`)
+
+- [ ] Read `searchParams` for `kicked=true`
+- [ ] If present, display a destructive toast or inline banner: **"You were removed from the game by the host."**
+- [ ] The message should not persist after the player re-joins or navigates away (clear param on mount)
+- [ ] Run `yarn test` ✅
+
+---
+
+### Step 10 — Host: Auto-removal in `useHostQuizPlayers` · Medium
+
+**File:** `src/hooks/use-host-quiz-players.ts`
+
+- [ ] Add constant: `const AUTO_REMOVE_THRESHOLD_MS = 5 * 60 * 1000` (5 minutes)
+- [ ] Create a `useRef<Set<string>>` called `autoRemovedRef` to track player IDs already triggered for auto-removal (prevents duplicate calls across polling intervals)
+- [ ] Add `removePlayerMutation` (`useMutation`) that calls `DELETE /api/quiz/{quizId}/player/{playerId}` with `{ reason: 'timeout' }`
+- [ ] After each successful poll result, iterate players:
+  ```
+  for each player where connectionStatus === 'disconnected':
+    if lastSeenAt is older than AUTO_REMOVE_THRESHOLD_MS AND playerId not in autoRemovedRef:
+      autoRemovedRef.current.add(playerId)
+      removePlayerMutation.mutate({ playerId, reason: 'timeout' })
+  ```
+- [ ] On successful mutation: invalidate `playerConnectionStatusQueryKey(quizId)` to refresh the list
+- [ ] Run `yarn test` ✅
+
+---
+
+### Step 11 — Host: Kick button in player list · Small
+
+**File:** `src/hooks/use-host-quiz-players.ts` + `src/components/host/player-list-with-status.tsx`
+
+- [ ] In `useHostQuizPlayers`, expose a `kickPlayer(playerId: string): void` function backed by `useMutation`:
+  - Calls `DELETE /api/quiz/{quizId}/player/{playerId}` with `{ reason: 'kicked' }`
+  - On success: invalidates player status query
+  - Expose `isKicking: boolean` (mutation pending state) for UI feedback
+- [ ] In `player-list-with-status.tsx`:
+  - Accept `onKick?: (playerId: string) => void` prop (or consume hook directly — decide based on existing component pattern)
+  - Add a small "Kick" button (`variant="destructive"` or icon button) per player row
+  - Disable button while `isKicking` is true for that player
+  - Show a confirmation prompt or use a simple click (decide based on UX — simple click is fine given the player gets a notification)
+- [ ] Run `yarn test` ✅
+
+---
+
+## Technical Decisions
+
+### Soft delete via `Removed` status (not hard delete)
+Keeps answer history and scores intact, which is important for audit and potential dispute resolution. Also simpler — no cascade-delete concerns in Prisma. A player marked `Removed` is invisible to the host list and cannot conflict with a rejoin attempt.
+
+### Auto-remove is host-side, not server-side
+Avoids background jobs/cron infrastructure. The host is already polling every 5 seconds via `useHostQuizPlayers`. The downside is auto-removal only happens while the host's browser is open, but this is acceptable since a host must be present for the game to be running.
+
+### `player:kicked` event on private channel
+Reuses the existing `player:{quizId}:{playerId}` broadcast pattern. The kicked player's browser receives the event and redirects before the server-side state is even fully propagated, giving a snappy UX. Players who are already disconnected (no active browser tab) will simply find they can't rejoin with the old playerId but can rejoin fresh via the join code.
+
+### Auto-remove guard (`Set` ref)
+Prevents the polling loop from calling DELETE on the same player multiple times before the query invalidation flushes the player out of the list. The ref persists across re-renders without triggering them.
+
+### Rejoin via same join code
+A `Removed` player is excluded from the name-duplicate check in `AddPlayerUseCase`. When they re-join, they get a new `playerId` (CUID) and start fresh with `score: 0`. Their old `Removed` record remains in the DB untouched.
+
+---
+
+## Success Criteria
+
+### Functional
+- [ ] Host can click "Kick" on any player in the player list at any point (lobby, active game)
+- [ ] Kicked player's browser immediately navigates to the join page with a "You were removed" message
+- [ ] Kicked player disappears from the host's player list within the next poll cycle (≤5s)
+- [ ] A player disconnected for 5+ minutes is auto-removed while the host's browser is open
+- [ ] Auto-removed player's browser receives the same redirect + message as a manually kicked player
+- [ ] A removed player can re-join using the quiz join code and start fresh
+
+### Non-functional
+- [ ] `yarn test` passes after every step (no regressions)
+- [ ] `yarn build` succeeds
+- [ ] TypeScript `strict` mode — no `any` types introduced
+- [ ] No new N+1 DB queries — removal is a single row update
+- [ ] Auto-remove does not spam the API (guarded by `Set` ref)
+
+---
+
+## Files Changed
+
+### New
+| File                                                             | Purpose            |
+| ---------------------------------------------------------------- | ------------------ |
+| `src/application/use-cases/remove-player.use-case.ts`            | Core removal logic |
+| `src/tests/application/use-cases/remove-player.use-case.test.ts` | Use case tests     |
+
+### Modified
+| File                                                                 | Change                                             |
+| -------------------------------------------------------------------- | -------------------------------------------------- |
+| `src/domain/entities/player.ts`                                      | Add `Removed` status + `removeFromGame()` method   |
+| `src/infrastructure/database/prisma/schema.prisma`                   | Add `Removed` to `PlayerStatus` enum               |
+| `src/application/use-cases/add-player.use-case.ts`                   | Exclude `Removed` from name duplicate check        |
+| `src/application/services/player-service.ts`                         | Add `removePlayer()` method                        |
+| `src/application/services/factories.ts`                              | Wire `RemovePlayerUseCase` (if needed)             |
+| `src/application/use-cases/get-player-connection-status.use-case.ts` | Filter out `Removed` players                       |
+| `src/infrastructure/realtime/broadcast-player-events.ts`             | Add `broadcastPlayerKicked()`                      |
+| `src/app/api/quiz/[quizId]/player/[playerId]/route.ts`               | Add `DELETE` handler                               |
+| `src/hooks/use-player-session.ts`                                    | Handle `player:kicked` realtime event              |
+| `src/hooks/use-host-quiz-players.ts`                                 | Auto-removal logic + `kickPlayer` mutation         |
+| `src/components/host/player-list-with-status.tsx`                    | "Kick" button per player row                       |
+| Player join/entry page (TBD path)                                    | Show "removed from game" message on `?kicked=true` |
+| Existing domain/use-case/repo tests                                  | Update for `Removed` status where affected         |
+
+---
+
+## Time Estimates
+
+| Step      | Task                                     | Estimate       |
+| --------- | ---------------------------------------- | -------------- |
+| 1         | Domain: Removed status + method + tests  | 20 min         |
+| 2         | Prisma schema migration                  | 10 min         |
+| 3         | RemovePlayerUseCase + tests              | 30 min         |
+| 4         | Fix name duplicate check for rejoin      | 20 min         |
+| 5         | Exclude Removed from status list         | 15 min         |
+| 6         | broadcastPlayerKicked                    | 10 min         |
+| 7         | DELETE API route                         | 20 min         |
+| 8         | Player UI: handle player:kicked          | 15 min         |
+| 9         | Player UI: kicked message on join page   | 20 min         |
+| 10        | Host: auto-removal in useHostQuizPlayers | 30 min         |
+| 11        | Host: kick button in player list         | 30 min         |
+| —         | Buffer (unexpected issues, test fixes)   | 30 min         |
+| **Total** |                                          | **~4.5 hours** |
+
+---
+
+## Notes & Observations
+
+*(Fill in during implementation)*
+
+---
+
+## Completion Checklist
+
+- [ ] All 11 steps checked off above
+- [ ] `yarn test` passes (no regressions)
+- [ ] `yarn build` succeeds
+- [ ] No TypeScript errors (`yarn lint`)
+- [ ] Manual verify: host kick works end-to-end in browser
+- [ ] Manual verify: auto-remove triggers after threshold (test with low threshold)
+- [ ] Manual verify: kicked player sees "removed" message and can rejoin
+- [ ] `docs/progress/dev-notes.md` updated with brief note

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prisma:migrate": "prisma migrate dev --schema ./src/infrastructure/database/prisma/schema.prisma",
     "prisma:seed": "prisma db seed --schema ./src/infrastructure/database/prisma/schema.prisma",
     "test": "vitest",
+    "test:run": "vitest --run",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",
     "test:e2e": "playwright test",

--- a/src/app/api/quiz/[quizId]/player/[playerId]/route.ts
+++ b/src/app/api/quiz/[quizId]/player/[playerId]/route.ts
@@ -1,11 +1,16 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getServices } from '@application/services/factories';
+import { broadcastPlayerKicked } from '@infrastructure/realtime/broadcast-player-events';
 import type { PlayerSessionDTO } from '@application/dtos/player-session.dto';
 
 const ParamsSchema = z.object({
   quizId: z.string().min(1),
   playerId: z.string().min(1),
+});
+
+const DeleteBodySchema = z.object({
+  reason: z.enum(['kicked', 'timeout']).default('kicked'),
 });
 
 type ErrorResponse = {
@@ -32,6 +37,34 @@ export async function GET(_request: Request, { params }: RouteContext) {
 
     const status = /not found|player/i.test(message) ? 404 : 400;
 
+    return NextResponse.json({ error: message } satisfies ErrorResponse, {
+      status,
+    });
+  }
+}
+
+export async function DELETE(request: Request, { params }: RouteContext) {
+  try {
+    const { quizId, playerId } = ParamsSchema.parse(await params);
+
+    let reason: 'kicked' | 'timeout' = 'kicked';
+    const contentType = request.headers.get('content-type') ?? '';
+    if (contentType.includes('application/json')) {
+      const body = await request.json().catch(() => ({}));
+      const parsed = DeleteBodySchema.safeParse(body);
+      if (parsed.success) {
+        reason = parsed.data.reason;
+      }
+    }
+
+    const { playerService } = getServices();
+    await playerService.removePlayer(playerId, quizId, reason);
+    await broadcastPlayerKicked(quizId, playerId, reason);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    const status = /not found/i.test(message) ? 404 : 400;
     return NextResponse.json({ error: message } satisfies ErrorResponse, {
       status,
     });

--- a/src/application/dtos/player.dto.ts
+++ b/src/application/dtos/player.dto.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 
-export const PlayerStatusDTO = z.enum(['Active', 'Disconnected', 'Finished']);
+export const PlayerStatusDTO = z.enum([
+  'Active',
+  'Disconnected',
+  'Finished',
+  'Removed',
+]);
 
 export const ConnectionStatusDTO = z.enum([
   'connected',

--- a/src/application/services/factories.ts
+++ b/src/application/services/factories.ts
@@ -11,6 +11,7 @@ import { UpdatePlayerStatusUseCase } from '@application/use-cases/update-player-
 import { UpdatePlayerPresenceUseCase } from '@application/use-cases/update-player-presence.use-case';
 import { GetPlayerSessionUseCase } from '@application/use-cases/get-player-session.use-case';
 import { GetPlayerConnectionStatusUseCase } from '@application/use-cases/get-player-connection-status.use-case';
+import { RemovePlayerUseCase } from '@application/use-cases/remove-player.use-case';
 import { PlayerService } from '@application/services/player-service';
 import { StartQuizUseCase } from '@application/use-cases/start-quiz.use-case';
 import { EndQuizUseCase } from '@application/use-cases/end-quiz.use-case';
@@ -140,6 +141,7 @@ export const getServices = (): ServiceContainer => {
     quizRepository,
     playerRepository
   );
+  const removePlayerUseCase = new RemovePlayerUseCase(playerRepository);
 
   const playerService = new PlayerService(
     addPlayerUseCase,
@@ -147,7 +149,8 @@ export const getServices = (): ServiceContainer => {
     updatePlayerPresenceUseCase,
     findPlayerByIdUseCase,
     listPlayersUseCase,
-    getPlayerSessionUseCase
+    getPlayerSessionUseCase,
+    removePlayerUseCase
   );
 
   const startQuizUseCase = new StartQuizUseCase(

--- a/src/application/services/player-service.ts
+++ b/src/application/services/player-service.ts
@@ -6,6 +6,7 @@ import { UpdatePlayerStatusUseCase } from '@application/use-cases/update-player-
 import { UpdatePlayerPresenceUseCase } from '@application/use-cases/update-player-presence.use-case';
 import { ListQuizPlayersUseCase } from '@application/use-cases/list-quiz-players.use-case';
 import { GetPlayerSessionUseCase } from '@application/use-cases/get-player-session.use-case';
+import { RemovePlayerUseCase } from '@application/use-cases/remove-player.use-case';
 import { Player, PlayerStatus } from '@domain/entities/player';
 
 export class PlayerService {
@@ -15,7 +16,8 @@ export class PlayerService {
     private readonly updatePlayerPresenceUseCase: UpdatePlayerPresenceUseCase,
     private readonly findPlayerByIdUseCase: FindPlayerByIdUseCase,
     private readonly listQuizPlayersUseCase: ListQuizPlayersUseCase,
-    private readonly getPlayerSessionUseCase: GetPlayerSessionUseCase
+    private readonly getPlayerSessionUseCase: GetPlayerSessionUseCase,
+    private readonly removePlayerUseCase: RemovePlayerUseCase
   ) {}
 
   async addPlayer(
@@ -50,5 +52,17 @@ export class PlayerService {
 
   async updatePresence(playerId: string, timestamp?: Date): Promise<void> {
     await this.updatePlayerPresenceUseCase.execute({ playerId, timestamp });
+  }
+
+  async removePlayer(
+    playerId: string,
+    quizId: string,
+    reason: 'kicked' | 'timeout'
+  ): Promise<{
+    playerId: string;
+    quizId: string;
+    reason: 'kicked' | 'timeout';
+  }> {
+    return this.removePlayerUseCase.execute(playerId, quizId, reason);
   }
 }

--- a/src/application/use-cases/add-player.use-case.ts
+++ b/src/application/use-cases/add-player.use-case.ts
@@ -1,6 +1,6 @@
 import { IPlayerRepository } from '@domain/repositories/player-repository';
 import { IQuizRepository } from '@domain/repositories/quiz-repository';
-import { Player } from '@domain/entities/player';
+import { Player, PlayerStatus } from '@domain/entities/player';
 
 export class AddPlayerUseCase {
   constructor(
@@ -27,7 +27,7 @@ export class AddPlayerUseCase {
       quizId,
       playerName
     );
-    if (duplicateName) {
+    if (duplicateName && duplicateName.status !== PlayerStatus.Removed) {
       throw new Error('Player name already taken for this quiz.');
     }
 

--- a/src/application/use-cases/get-player-connection-status.use-case.ts
+++ b/src/application/use-cases/get-player-connection-status.use-case.ts
@@ -6,6 +6,7 @@ import {
 import { mapPlayerToDTO } from '@application/mappers/player-mapper';
 import type { IPlayerRepository } from '@domain/repositories/player-repository';
 import type { IQuizRepository } from '@domain/repositories/quiz-repository';
+import { PlayerStatus } from '@domain/entities/player';
 
 /**
  * GetPlayerConnectionStatusUseCase
@@ -37,14 +38,17 @@ export class GetPlayerConnectionStatusUseCase {
       throw new Error(`Quiz with ID ${quizId} not found.`);
     }
 
-    // Fetch all players for this quiz
+    // Fetch all players for this quiz, excluding Removed ones
     const players = await this.playerRepository.listByQuizId(quizId);
-    if (players.length === 0) {
+    const activePlayers = players.filter(
+      (p) => p.status !== PlayerStatus.Removed
+    );
+    if (activePlayers.length === 0) {
       return [];
     }
 
     // Map to DTOs with connection status
-    const playerDTOs = players.map((player) =>
+    const playerDTOs = activePlayers.map((player) =>
       mapPlayerToDTO(player, {
         includeConnectionStatus: true,
         now,

--- a/src/application/use-cases/remove-player.use-case.ts
+++ b/src/application/use-cases/remove-player.use-case.ts
@@ -1,0 +1,26 @@
+import type { IPlayerRepository } from '@domain/repositories/player-repository';
+
+export class RemovePlayerUseCase {
+  constructor(private readonly playerRepository: IPlayerRepository) {}
+
+  async execute(
+    playerId: string,
+    quizId: string,
+    reason: 'kicked' | 'timeout'
+  ): Promise<{
+    playerId: string;
+    quizId: string;
+    reason: 'kicked' | 'timeout';
+  }> {
+    const player = await this.playerRepository.findById(playerId);
+    if (!player) {
+      throw new Error(`Player with ID ${playerId} not found.`);
+    }
+    if (player.quizId !== quizId) {
+      throw new Error(`Player with ID ${playerId} not found.`);
+    }
+    player.removeFromGame(reason);
+    await this.playerRepository.save(player);
+    return { playerId, quizId, reason };
+  }
+}

--- a/src/components/host/player-list-with-status.tsx
+++ b/src/components/host/player-list-with-status.tsx
@@ -3,6 +3,7 @@
 import { useHostQuizPlayers } from '@/hooks/use-host-quiz-players';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 
 interface PlayerListWithStatusProps {
   quizId: string;
@@ -20,6 +21,8 @@ export function PlayerListWithStatus({
     data: players = [],
     isLoading,
     error,
+    kickPlayer,
+    isKicking,
   } = useHostQuizPlayers(quizId, {
     refetchInterval: pollInterval,
   });
@@ -79,7 +82,18 @@ export function PlayerListWithStatus({
             >
               <div className="flex items-center justify-between gap-2">
                 <p className="font-medium">{player.name}</p>
-                <ConnectionStatusBadge status={player.connectionStatus} />
+                <div className="flex items-center gap-2">
+                  <ConnectionStatusBadge status={player.connectionStatus} />
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    disabled={isKicking}
+                    onClick={() => kickPlayer(player.playerId)}
+                    className="h-6 px-2 text-xs"
+                  >
+                    Kick
+                  </Button>
+                </div>
               </div>
               {player.lastSeenAt && (
                 <p className="text-xs text-muted-foreground">

--- a/src/components/player/player-join-form.tsx
+++ b/src/components/player/player-join-form.tsx
@@ -41,6 +41,19 @@ export function PlayerJoinForm() {
     null
   );
   const [quizInfo, setQuizInfo] = useState<JoinResponse['quiz'] | null>(null);
+  const [showKickedMessage] = useState(
+    () => searchParams.get('kicked') === 'true'
+  );
+
+  // Clear the ?kicked=true param from the URL after mount so it won't
+  // re-appear on a manual page refresh.
+  useEffect(() => {
+    if (searchParams.get('kicked') === 'true') {
+      const url = new URL(window.location.href);
+      url.searchParams.delete('kicked');
+      window.history.replaceState(null, '', url.toString());
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     try {
@@ -154,6 +167,15 @@ export function PlayerJoinForm() {
             </div>
           )}
         </header>
+
+        {showKickedMessage && (
+          <div
+            role="alert"
+            className="rounded-2xl border border-amber-400/30 bg-amber-400/10 px-5 py-4 text-sm text-amber-200"
+          >
+            You were removed from the game by the host.
+          </div>
+        )}
 
         <form
           onSubmit={handleJoin}

--- a/src/domain/entities/player.ts
+++ b/src/domain/entities/player.ts
@@ -7,6 +7,7 @@ export enum PlayerStatus {
   Active = 'Active',
   Disconnected = 'Disconnected',
   Finished = 'Finished',
+  Removed = 'Removed',
 }
 
 export class Player {
@@ -41,6 +42,19 @@ export class Player {
 
   updateLastSeenAt(timestamp: Date = new Date()): void {
     this.lastSeenAt = timestamp;
+  }
+
+  /**
+   * Removes the player from the game. The reason is informational for the
+   * application layer (realtime events, audit); the domain entity does not
+   * store it — status alone is sufficient.
+   */
+  removeFromGame(reason: 'kicked' | 'timeout'): void {
+    if (this.status === PlayerStatus.Removed) {
+      throw new Error('Player has already been removed from the game.');
+    }
+    void reason;
+    this.status = PlayerStatus.Removed;
   }
 
   /**

--- a/src/hooks/use-host-quiz-players.ts
+++ b/src/hooks/use-host-quiz-players.ts
@@ -1,6 +1,7 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { PlayerConnectionStatusDTO } from '@application/dtos/player-connection-status.dto.ts';
 
 /**
@@ -8,6 +9,8 @@ import type { PlayerConnectionStatusDTO } from '@application/dtos/player-connect
  */
 export const playerConnectionStatusQueryKey = (quizId: string) =>
   ['quiz', quizId, 'players', 'status'] as const;
+
+const AUTO_REMOVE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
  * Fetch player connection status from the API
@@ -63,8 +66,10 @@ export function useHostQuizPlayers(
   }
 ) {
   const { enabled = true, refetchInterval = 5000 } = options ?? {};
+  const queryClient = useQueryClient();
+  const autoRemovedRef = useRef<Set<string>>(new Set());
 
-  return useQuery({
+  const query = useQuery({
     queryKey: playerConnectionStatusQueryKey(quizId),
     queryFn: () => fetchPlayerConnectionStatus(quizId),
     enabled: enabled && !!quizId,
@@ -74,4 +79,78 @@ export function useHostQuizPlayers(
     retry: 2, // Retry twice on network failure
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
   });
+
+  const removePlayerMutation = useMutation({
+    mutationFn: ({
+      playerId,
+      reason,
+    }: {
+      playerId: string;
+      reason: 'kicked' | 'timeout';
+    }) =>
+      fetch(`/api/quiz/${quizId}/player/${playerId}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason }),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: playerConnectionStatusQueryKey(quizId),
+      });
+    },
+  });
+
+  const kickPlayerMutation = useMutation({
+    mutationFn: (playerId: string) =>
+      fetch(`/api/quiz/${quizId}/player/${playerId}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'kicked' }),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: playerConnectionStatusQueryKey(quizId),
+      });
+    },
+    onError: (error) => {
+      console.error('Failed to kick player:', error);
+    },
+  });
+
+  // Auto-remove players disconnected for longer than AUTO_REMOVE_THRESHOLD_MS.
+  // Only query.data is a meaningful dep — mutations and the ref are stable.
+  useEffect(() => {
+    const players = query.data;
+    if (!players) return;
+
+    const now = Date.now();
+    for (const player of players) {
+      if (
+        player.connectionStatus === 'disconnected' &&
+        player.lastSeenAt !== null &&
+        !autoRemovedRef.current.has(player.playerId)
+      ) {
+        const lastSeenMs = new Date(player.lastSeenAt).getTime();
+        if (now - lastSeenMs > AUTO_REMOVE_THRESHOLD_MS) {
+          autoRemovedRef.current.add(player.playerId);
+          removePlayerMutation.mutate(
+            { playerId: player.playerId, reason: 'timeout' },
+            {
+              onError: () => {
+                // Allow retry on next polling cycle
+                autoRemovedRef.current.delete(player.playerId);
+              },
+            }
+          );
+        }
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query.data]); // removePlayerMutation and autoRemovedRef are stable across renders
+
+  return {
+    ...query,
+    kickPlayer: (playerId: string) => kickPlayerMutation.mutate(playerId),
+    isKicking: kickPlayerMutation.isPending,
+  };
 }

--- a/src/hooks/use-player-session.ts
+++ b/src/hooks/use-player-session.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { PlayerSessionDTO } from '@application/dtos/player-session.dto';
 import type { QuizDTO } from '@application/dtos/quiz.dto';
@@ -64,6 +65,7 @@ export const usePlayerSession = ({
 }: UsePlayerSessionOptions) => {
   const realtimeClient = useRealtimeClient();
   const queryClient = useQueryClient();
+  const router = useRouter();
   const queryKey = playerSessionQueryKey(quizId, playerId);
   const quizChannelName = `quiz:${quizId}`;
   const playerChannelName = `player:${quizId}:${playerId}`;
@@ -118,6 +120,19 @@ export const usePlayerSession = ({
 
     return unsubscribe;
   }, [playerChannelName, realtimeClient, queryClient, queryKey]);
+
+  // Subscribe to player kick events
+  useEffect(() => {
+    const unsubscribe = realtimeClient.subscribe<Record<string, never>>(
+      playerChannelName,
+      'player:kicked',
+      () => {
+        router.push('/join?kicked=true');
+      }
+    );
+
+    return unsubscribe;
+  }, [playerChannelName, realtimeClient, router]);
 
   const submitAnswerMutation = useMutation({
     mutationFn: ({

--- a/src/infrastructure/database/prisma/migrations/20260505202129_add_removed_player_status/migration.sql
+++ b/src/infrastructure/database/prisma/migrations/20260505202129_add_removed_player_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "PlayerStatus" ADD VALUE 'Removed';

--- a/src/infrastructure/database/prisma/schema.prisma
+++ b/src/infrastructure/database/prisma/schema.prisma
@@ -130,6 +130,7 @@ enum PlayerStatus {
   Active
   Disconnected
   Finished
+  Removed
 }
 
 enum QuestionType {

--- a/src/infrastructure/realtime/broadcast-player-events.ts
+++ b/src/infrastructure/realtime/broadcast-player-events.ts
@@ -1,5 +1,6 @@
 import type { PlayerSessionDTO } from '@application/dtos/player-session.dto';
 import { broadcastPool } from './broadcast-channel-pool';
+
 import { getSupabaseServerClient } from './supabase-server-client';
 
 /**
@@ -51,4 +52,15 @@ export const broadcastPlayerUpdate = async (
   session: PlayerSessionDTO
 ): Promise<void> => {
   await broadcastPlayerEvent(quizId, playerId, 'player:update', session);
+};
+
+/**
+ * Broadcasts a kick/removal notification to a specific player.
+ */
+export const broadcastPlayerKicked = async (
+  quizId: string,
+  playerId: string,
+  reason: 'kicked' | 'timeout'
+): Promise<void> => {
+  await broadcastPlayerEvent(quizId, playerId, 'player:kicked', { reason });
 };

--- a/src/tests/application/use-cases/add-player-use-case.test.ts
+++ b/src/tests/application/use-cases/add-player-use-case.test.ts
@@ -1,7 +1,7 @@
 import { AddPlayerUseCase } from '@application/use-cases/add-player.use-case';
 import { QuizSessionAggregate } from '@domain/aggregates/quiz-session-aggregate';
 import { Quiz } from '@domain/entities/quiz';
-import { Player } from '@domain/entities/player';
+import { Player, PlayerStatus } from '@domain/entities/player';
 import { IQuizRepository } from '@domain/repositories/quiz-repository';
 import { IPlayerRepository } from '@domain/repositories/player-repository';
 import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
@@ -99,5 +99,28 @@ describe('AddPlayerUseCase', () => {
     ).rejects.toThrow('Player name already taken for this quiz.');
     expect(playerRepository.save).not.toHaveBeenCalled();
     expect(quizRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should allow rejoin when existing player with same name is Removed', async () => {
+    const quiz = new QuizSessionAggregate(
+      new Quiz('quiz1', 'Sample Quiz', [], {
+        timePerQuestion: 30,
+        allowSkipping: true,
+      }),
+      30
+    );
+    const removedPlayer = new Player('old-p', 'Player 1', 'quiz1');
+    removedPlayer.status = PlayerStatus.Removed;
+
+    quizRepository.findById.mockResolvedValue(quiz);
+    playerRepository.findById.mockResolvedValue(null);
+    playerRepository.findByQuizIdAndName.mockResolvedValue(removedPlayer);
+
+    await expect(
+      addPlayerUseCase.execute('quiz1', 'p2', 'Player 1')
+    ).resolves.toBeUndefined();
+    expect(playerRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'p2', name: 'Player 1' })
+    );
   });
 });

--- a/src/tests/application/use-cases/get-player-connection-status.use-case.test.ts
+++ b/src/tests/application/use-cases/get-player-connection-status.use-case.test.ts
@@ -1,7 +1,7 @@
 import { GetPlayerConnectionStatusUseCase } from '@application/use-cases/get-player-connection-status.use-case';
 import type { IPlayerRepository } from '@domain/repositories/player-repository';
 import type { IQuizRepository } from '@domain/repositories/quiz-repository';
-import { Player } from '@domain/entities/player';
+import { Player, PlayerStatus } from '@domain/entities/player';
 import { Quiz } from '@domain/entities/quiz';
 import { QuizSessionAggregate } from '@domain/aggregates/quiz-session-aggregate';
 import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
@@ -227,6 +227,34 @@ describe('GetPlayerConnectionStatusUseCase', () => {
       expect(result[3].connectionStatus).toBe('away');
       expect(result[8].connectionStatus).toBe('away');
       expect(result[9].connectionStatus).toBe('disconnected');
+    });
+
+    it('should exclude Removed players from the result', async () => {
+      const quizId = 'quiz-1';
+      const quiz = new Quiz(quizId, 'Test Quiz', [], {
+        timePerQuestion: 30,
+        allowSkipping: true,
+        scoringAlgorithm: 'FIXED',
+      });
+      const quizAggregate = new QuizSessionAggregate(quiz, 30);
+
+      const activePlayer = new Player('p1', 'Active Player', quizId);
+      activePlayer.lastSeenAt = new Date(baseTime.getTime() - 5_000);
+
+      const removedPlayer = new Player('p2', 'Removed Player', quizId);
+      removedPlayer.lastSeenAt = new Date(baseTime.getTime() - 5_000);
+      removedPlayer.status = PlayerStatus.Removed;
+
+      quizRepository.findById.mockResolvedValue(quizAggregate);
+      playerRepository.listByQuizId.mockResolvedValue([
+        activePlayer,
+        removedPlayer,
+      ]);
+
+      const result = await useCase.execute(quizId, baseTime);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].playerId).toBe('p1');
     });
   });
 });

--- a/src/tests/application/use-cases/remove-player.use-case.test.ts
+++ b/src/tests/application/use-cases/remove-player.use-case.test.ts
@@ -1,0 +1,85 @@
+import { RemovePlayerUseCase } from '@application/use-cases/remove-player.use-case';
+import { Player, PlayerStatus } from '@domain/entities/player';
+import type { IPlayerRepository } from '@domain/repositories/player-repository';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
+
+describe('RemovePlayerUseCase', () => {
+  let playerRepository: Mocked<IPlayerRepository>;
+  let useCase: RemovePlayerUseCase;
+
+  beforeEach(() => {
+    playerRepository = {
+      findById: vi.fn(),
+      listByQuizId: vi.fn(),
+      findByQuizIdAndName: vi.fn(),
+      save: vi.fn(),
+      updateStatus: vi.fn(),
+      updateScore: vi.fn(),
+      updateLastSeenAt: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as Mocked<IPlayerRepository>;
+    useCase = new RemovePlayerUseCase(playerRepository);
+  });
+
+  it('should mark player as Removed and return result for reason "kicked"', async () => {
+    const player = new Player('p1', 'Alice', 'quiz1');
+    playerRepository.findById.mockResolvedValue(player);
+    playerRepository.save.mockResolvedValue(undefined);
+
+    const result = await useCase.execute('p1', 'quiz1', 'kicked');
+
+    expect(player.status).toBe(PlayerStatus.Removed);
+    expect(playerRepository.save).toHaveBeenCalledWith(player);
+    expect(result).toEqual({
+      playerId: 'p1',
+      quizId: 'quiz1',
+      reason: 'kicked',
+    });
+  });
+
+  it('should mark player as Removed and return result for reason "timeout"', async () => {
+    const player = new Player('p1', 'Alice', 'quiz1');
+    playerRepository.findById.mockResolvedValue(player);
+    playerRepository.save.mockResolvedValue(undefined);
+
+    const result = await useCase.execute('p1', 'quiz1', 'timeout');
+
+    expect(player.status).toBe(PlayerStatus.Removed);
+    expect(playerRepository.save).toHaveBeenCalledWith(player);
+    expect(result).toEqual({
+      playerId: 'p1',
+      quizId: 'quiz1',
+      reason: 'timeout',
+    });
+  });
+
+  it('should throw when player is not found', async () => {
+    playerRepository.findById.mockResolvedValue(null);
+
+    await expect(useCase.execute('p1', 'quiz1', 'kicked')).rejects.toThrow(
+      'Player with ID p1 not found.'
+    );
+    expect(playerRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should throw when player belongs to a different quiz', async () => {
+    const player = new Player('p1', 'Alice', 'other-quiz');
+    playerRepository.findById.mockResolvedValue(player);
+
+    await expect(useCase.execute('p1', 'quiz1', 'kicked')).rejects.toThrow(
+      'Player with ID p1 not found.'
+    );
+    expect(playerRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should throw when player is already Removed', async () => {
+    const player = new Player('p1', 'Alice', 'quiz1');
+    player.removeFromGame('kicked'); // set to Removed first
+    playerRepository.findById.mockResolvedValue(player);
+
+    await expect(useCase.execute('p1', 'quiz1', 'kicked')).rejects.toThrow(
+      'Player has already been removed from the game.'
+    );
+    expect(playerRepository.save).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/domain/entities/player.test.ts
+++ b/src/tests/domain/entities/player.test.ts
@@ -123,4 +123,27 @@ describe('Player', () => {
       expect(player.getConnectionStatusType(now)).toBe('disconnected');
     });
   });
+
+  describe('removeFromGame', () => {
+    it('should set status to Removed when called with kicked reason from Active', () => {
+      const player = new Player('1', 'John Doe', 'quiz-1');
+      player.removeFromGame('kicked');
+      expect(player.status).toBe(PlayerStatus.Removed);
+    });
+
+    it('should set status to Removed when called with timeout reason from Disconnected', () => {
+      const player = new Player('1', 'John Doe', 'quiz-1');
+      player.updateStatus(PlayerStatus.Disconnected);
+      player.removeFromGame('timeout');
+      expect(player.status).toBe(PlayerStatus.Removed);
+    });
+
+    it('should throw when player is already Removed', () => {
+      const player = new Player('1', 'John Doe', 'quiz-1');
+      player.removeFromGame('kicked');
+      expect(() => player.removeFromGame('kicked')).toThrow(
+        'Player has already been removed from the game.'
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Implements the full Player Kick & Auto-Remove feature. Hosts can now manually kick any player from a game, and players who have been disconnected for 5+ minutes are automatically removed while the host's browser is open.

## Changes

### Domain
- Added `Removed = 'Removed'` to `PlayerStatus` enum
- Added `removeFromGame(reason: 'kicked' | 'timeout'): void` to `Player` entity (throws if already `Removed`)

### Infrastructure
- Prisma schema: added `Removed` to `enum PlayerStatus` (`add_removed_player_status` migration)
- `broadcastPlayerKicked(quizId, playerId, reason)` — sends `player:kicked` on private `player:{quizId}:{playerId}` channel

### Application
- `RemovePlayerUseCase` — validates player + quiz ownership, calls domain method, saves
- `PlayerService.removePlayer(playerId, quizId, reason)`
- `AddPlayerUseCase` — name duplicate check now excludes `Removed` players (enables rejoin)
- `GetPlayerConnectionStatusUseCase` — filters out `Removed` players from host list
- `PlayerStatusDTO` — added `'Removed'` variant

### API
- `DELETE /api/quiz/[quizId]/player/[playerId]` — optional `{ reason?: 'kicked' | 'timeout' }` body, defaults to `'kicked'`

### Player UI
- `usePlayerSession` — subscribes to `player:kicked` event → `router.push('/join?kicked=true')`
- Join page — amber "You were removed from the game by the host." banner when `?kicked=true`

### Host UI
- `useHostQuizPlayers` — exposes `kickPlayer(playerId)` and `isKicking`; auto-removes players disconnected >5 min via polling loop with `Set` deduplication ref and retry-on-error logic
- `PlayerListWithStatus` — Kick button (destructive) per player row

## Test Results
- 413 unit tests passing, 0 failures
- `yarn build` ✅
- `yarn lint` — 0 errors
- Manual E2E verified: kick flow, redirect, "removed" banner, player disappears from host list

## Related
- Plan: `docs/progress/plans/2026-05-05-player-kick-and-auto-remove.md`