### PR TITLE
fix: exclude Removed players from host live game views

### DIFF
--- a/src/application/use-cases/get-quiz-state.use-case.ts
+++ b/src/application/use-cases/get-quiz-state.use-case.ts
@@ -1,6 +1,7 @@
 import type { QuizDTO as QuizDTOType } from '@application/dtos/quiz.dto';
 import { mapQuizToDTO } from '@application/mappers/quiz-mapper';
 import type { Player } from '@domain/entities/player';
+import { PlayerStatus } from '@domain/entities/player';
 import type { IPlayerRepository } from '@domain/repositories/player-repository';
 import type { IQuizRepository } from '@domain/repositories/quiz-repository';
 
@@ -22,8 +23,9 @@ export class GetQuizStateUseCase {
       )
     );
 
-    const hydratedPlayers = players.filter((player): player is Player =>
-      Boolean(player)
+    const hydratedPlayers = players.filter(
+      (player): player is Player =>
+        !!player && player.status !== PlayerStatus.Removed
     );
 
     return mapQuizToDTO(quizAggregate, hydratedPlayers);

--- a/src/tests/application/use-cases/get-quiz-state-use-case.test.ts
+++ b/src/tests/application/use-cases/get-quiz-state-use-case.test.ts
@@ -78,4 +78,32 @@ describe('GetQuizStateUseCase', () => {
       'Quiz with ID missing not found.'
     );
   });
+
+  it('excludes Removed players from the returned DTO', async () => {
+    const quiz = new Quiz('quiz-1', 'General Knowledge', [], {
+      allowSkipping: false,
+      timePerQuestion: 30,
+    });
+    const aggregate = new QuizSessionAggregate(quiz, 30);
+    aggregate.addPlayer('player-active');
+    aggregate.addPlayer('player-removed');
+
+    const activePlayer = new Player('player-active', 'Alice', 'quiz-1');
+    const removedPlayer = new Player('player-removed', 'Bob', 'quiz-1');
+    removedPlayer.removeFromGame('kicked');
+
+    quizRepository.findById.mockResolvedValue(aggregate);
+    playerRepository.findById
+      .mockResolvedValueOnce(activePlayer)
+      .mockResolvedValueOnce(removedPlayer);
+
+    const dto = await useCase.execute('quiz-1');
+
+    expect(dto.players).toHaveLength(1);
+    expect(dto.players[0]).toMatchObject({
+      id: 'player-active',
+      name: 'Alice',
+    });
+    expect(dto.players.find((p) => p.id === 'player-removed')).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Problem

After implementing the player kick & auto-remove feature, kicked/auto-removed players were still visible on the host's live game screen because `GetQuizStateUseCase` returned all players regardless of status.

**Impact:**
- **Lobby view** — kicked players appeared as name badges indefinitely
- **Question view** — `quiz.players.length` denominator was inflated (e.g. "3 / 5 answered" when 2 players had been kicked)
- **Round results** — removed players could appear on the leaderboard

## Fix

Added a single filter in `GetQuizStateUseCase` to exclude `PlayerStatus.Removed` players before mapping to `QuizDTO`. Since all host views derive their player data from `QuizDTO.players`, this fixes all three affected components in one place.

```ts
const hydratedPlayers = players.filter(
  (player): player is Player =>
    Boolean(player) && player.status !== PlayerStatus.Removed
);
```

## Tests

Added a new test case to `get-quiz-state-use-case.test.ts` verifying that a removed player is excluded from the returned DTO while an active player is still included. All 3 tests pass.