### PR TITLE
fix: cap pg pool size to prevent EMAXCONN on Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,15 @@
 # Prisma / Postgres (Vitest auto-loads this file; never store production secrets here.)
+#
+# In production/Vercel, use Supabase's Supavisor (pgbouncer) pooler URL for DATABASE_URL
+# to avoid exhausting Postgres max connections (200 limit). Find it in:
+# Supabase Dashboard → Project Settings → Database → Connection string → Transaction mode
+# Example pooler URL (port 6543, pgbouncer=true):
+# DATABASE_URL="postgresql://postgres.PROJECT:[PASSWORD]@aws-0-REGION.pooler.supabase.com:6543/postgres?pgbouncer=true"
+#
+# DIRECT_URL is required for Prisma migrations (bypasses pgbouncer):
+# DIRECT_URL="postgresql://postgres.PROJECT:[PASSWORD]@aws-0-REGION.pooler.supabase.com:5432/postgres"
 DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/quiz_game?schema=public"
+DIRECT_URL="postgresql://USER:PASSWORD@HOST:5432/quiz_game?schema=public"
 SHADOW_DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/quiz_game_shadow?schema=public"
 DATABASE_URL_TEST="postgresql://USER:PASSWORD@HOST:5432/quiz_game_test?schema=public"
 ENABLE_PRISMA_INTEGRATION_TESTS="false"

--- a/src/infrastructure/database/prisma/client.ts
+++ b/src/infrastructure/database/prisma/client.ts
@@ -10,6 +10,11 @@ if (!connectionString) {
 
 const adapter = new PrismaPg({
   connectionString,
+  // Limit pool size per serverless function instance.
+  // In a serverless environment (Vercel), each lambda can open its own pool;
+  // keeping max low prevents exhausting Supabase's connection limit (200).
+  // The primary fix is using the Supavisor pooler URL (port 6543) in DATABASE_URL.
+  max: 2,
 });
 
 const globalForPrisma = globalThis as unknown as {


### PR DESCRIPTION
## Problem

During live quiz games with multiple concurrent players, the app hit Supabase's `(EMAXCONN) max client connections reached, limit: 200` error.

**Root cause:** `@prisma/adapter-pg` creates a `pg.Pool` with `max: 10` connections by default. On Vercel, each serverless lambda instance gets its own pool. With multiple concurrent players polling every 5s (quiz state, player status, answer submissions), many lambda instances can be alive simultaneously — each holding up to 10 pooler connections, quickly exhausting Supabase Supavisor's 200-connection limit.

## Fix

Set `max: 2` on the `PrismaPg` adapter in `client.ts`. With 2 connections per lambda instance instead of 10, the headroom is much larger (e.g. 20 lambdas × 2 = 40 connections, well under 200).

The primary architectural fix is already in place: `DATABASE_URL` points to the Supabase Supavisor pooler (port 6543, `pgbouncer=true`), so connections are multiplexed rather than going directly to Postgres.

## Also updated

`.env.example` now documents the correct `DATABASE_URL` (pooler, port 6543) vs `DIRECT_URL` (direct, port 5432 — for migrations only) pattern for Supabase deployments.