### PR TITLE
fix: enforce LF line endings across the repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "files.eol": "\n"
 }


### PR DESCRIPTION
## Problem

On Windows, Git's `core.autocrlf=true` converts LF→CRLF on checkout, causing ESLint to report hundreds of `linebreak-style` and `prettier/prettier` CRLF errors after every pull.

## Solution

Two minimal changes:

- **`.gitattributes`** — `* text=auto eol=lf` tells Git to always store and check out files with LF, regardless of OS or local Git config
- **`.vscode/settings.json`** — `"files.eol": "\n"` ensures VS Code saves new files with LF by default

## Result

- `yarn lint` passes with 0 errors (only 5 pre-existing unrelated warnings remain)
- No CRLF issues after future pulls on Windows