### PR TITLE
fix: replace non-existent github MCP package with correct one

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -32,7 +32,6 @@
     ]
   },
   "enabledMcpjsonServers": [
-    "github",
     "supabase",
     "playwright",
     "context7"

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,7 @@
     "github": {
       "type": "stdio",
       "command": "cmd",
-      "args": ["/c", "npx", "-y", "@anthropic-ai/github-mcp-server"],
+      "args": ["/c", "npx", "-y", "@modelcontextprotocol/server-github"],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,12 @@
     "github": {
       "type": "stdio",
       "command": "cmd",
-      "args": ["/c", "npx", "-y", "@modelcontextprotocol/server-github"],
+      "args": [
+        "/c",
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
@@ -15,13 +20,22 @@
     "playwright": {
       "type": "stdio",
       "command": "cmd",
-      "args": ["/c", "npx", "@playwright/mcp@latest"],
+      "args": [
+        "/c",
+        "npx",
+        "@playwright/mcp@latest"
+      ],
       "env": {}
     },
     "context7": {
       "type": "stdio",
       "command": "cmd",
-      "args": ["/c", "npx", "-y", "@upstash/context7-mcp@latest"]
+      "args": [
+        "/c",
+        "npx",
+        "-y",
+        "@upstash/context7-mcp@latest"
+      ]
     }
   }
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -29,7 +29,7 @@
       "headers": {
         "CONTEXT7_API_KEY": "${input:CONTEXT7_API_KEY}"
       }
-    }
+    },
   },
   "inputs": [
     {


### PR DESCRIPTION
## Problem

The `.mcp.json` (Claude Code) config referenced `@anthropic-ai/github-mcp-server` which does not exist on npm, causing the GitHub MCP server to fail on every startup with a 404 error.

## Changes

- **`.mcp.json`**: Replace `@anthropic-ai/github-mcp-server` with `@modelcontextprotocol/server-github` (the correct package)
- **`.claude/settings.local.json`**: Remove `"github"` from `enabledMcpjsonServers` (was referencing the broken server)
- **`.vscode/mcp.json`**: Minor cleanup (no functional change)