### PR TITLE
ci: fix build job env fallbacks for Dependabot PRs, bump setup-node to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'yarn'
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'yarn'
@@ -60,7 +60,7 @@ jobs:
       - name: Build
         run: yarn build
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/postgres' }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-service-role-key' }}


### PR DESCRIPTION
## Problem

All Dependabot PRs are failing the **Build Check** job. Dependabot runs with its own isolated secret store — secrets like `DATABASE_URL` are empty unless explicitly added under *Settings → Security → Dependabot secrets*. During `next build`, Next.js collects page data from `layout.tsx`, which calls `validateEnvironment()`. That function throws when any required env var is missing, killing the build.

The `Lint & Unit Tests` job already has a dummy fallback for `prisma:generate` but the `Build` job had none.

## Fix

**Option A — dummy env-var fallbacks in the CI workflow**

Mirrors the existing pattern on the `prisma:generate` step. No application code changes needed; `next build` only needs the strings to be non-empty — it never connects to a real DB at build time.

### Changes

- Added `|| 'placeholder'` fallbacks to all 4 env vars in the `build` job
- Bumped `actions/setup-node` from `v4` → `v5` in both jobs (Node 20 deprecated on runners, end-of-life September 16 2026)

Once merged to `master`, all open Dependabot PRs can be rebased (`@dependabot rebase`) to pick up the fixed workflow.