### PR TITLE
docs: backfill session logs for May 2-9 and add documentation practices

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -608,6 +608,60 @@ Example: Adding a field like `playerRank` requires touching:
 
 **Stale docs are treated as regressions** since future agents rely on them.
 
+### Decision Logging
+
+**Record the WHY, not just the WHAT.** The commit message records what changed; the session file must record why the alternative was rejected.
+
+Minimum decision entry format (use in plan files and session files):
+```
+**Decision: [short label]**
+[One sentence on what was chosen.] [One sentence on the alternative considered.] [One sentence on why this was preferred.]
+```
+
+**Always document when you:**
+- Choose soft delete over hard delete (data retention trade-off)
+- Pick a threshold value (timeout, interval, pool size) — explain the reasoning, not just the value
+- Disable a linter rule — name the false-positive pattern
+- Use a workaround for a framework quirk — name the quirk
+- Defer a feature — say what it's deferred *to* and why it was deprioritised now
+
+### What Goes Where
+
+| Artifact | When to create | What to put in it |
+|----------|---------------|-------------------|
+| **Plan file** (`docs/progress/plans/`) | Before starting any feature >5 steps or >2h | Steps with checkboxes, technical decisions, time estimates, success criteria |
+| **Session file** (`docs/progress/sessions/`) | After completing any significant session | What was built, key decisions with rationale, verification results, files changed |
+| **dev-notes.md** | Daily — append-only bullet log | One-liner per feature/fix, link to session file |
+| **PROGRESS.md** | After each session | Brief session entry in chronological list + execution log |
+| **Commit message** | Every commit | *What* changed and *why* (not how) |
+
+### When a Session File Is Required
+
+Create a session file whenever:
+- A feature plan was executed (session file = companion to plan file)
+- A significant bug was fixed with a non-obvious root cause
+- A maintenance or upgrade session touched many files
+- A decision was made that a future developer would need to understand
+
+Skip the session file for: single-file typo fixes, trivial dependency bumps, formatting-only changes.
+
+### The Decision Trail Habit
+
+Before closing a plan or session, ask: *"If I came back to this in 6 months, what would confuse me?"*
+
+Common things to capture:
+- Why a threshold is the value it is (e.g. "5 min auto-remove: matches the 120s disconnected threshold × 2.5, giving a visible grace period without requiring background jobs")
+- Why a pool cap is set where it is (e.g. "`max: 2` because serverless handles one request at a time; 2 allows parallel queries within a request without exhausting Supabase's per-connection limit")
+- What alternatives were rejected and why (e.g. "server-side auto-remove via cron was rejected because it requires background job infrastructure we don't have; host-side is acceptable since the host must be present for the game to run")
+
+### Maintenance Sessions
+
+Security and dependency upgrade sessions must record:
+- What drove the upgrade (CVE IDs or Dependabot alerts, not just "security")
+- What broke during the upgrade and how it was fixed
+- Any rules disabled or workarounds added, and why
+- What remains unresolved (e.g. transitive CVEs with no available fix)
+
 ## Styling & UI Components
 - **Tailwind 4** configured in `src/app/globals.css` with OKLCH tokens and `@custom-variant dark`
 - Use `cn()` helper from `src/lib/utils.ts` for conditional classes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,64 @@ This file is a condensed quick reference; the full guide has comprehensive examp
 
 See `.github/copilot-instructions.md` "Planning Workflow (Scrum Board Alternative)" for full details.
 
+## Documentation Practices
+
+Good documentation is written at the moment of decision, not reconstructed later. These practices apply to all work in this repo.
+
+### Decision Logging
+
+**Record the WHY, not just the WHAT.** The commit message records what changed; the session file must record why the alternative was rejected.
+
+Minimum decision entry format (use in plan files and session files):
+```
+**Decision: [short label]**
+[One sentence on what was chosen.] [One sentence on the alternative considered.] [One sentence on why this was preferred.]
+```
+
+**Always document when you:**
+- Choose soft delete over hard delete (data retention trade-off)
+- Pick a threshold value (timeout, interval, pool size) — explain the reasoning, not just the value
+- Disable a linter rule — name the false-positive pattern
+- Use a workaround for a framework quirk — name the quirk
+- Defer a feature — say what it's deferred *to* and why it was deprioritised now
+
+### What Goes Where
+
+| Artifact | When to create | What to put in it |
+|----------|---------------|-------------------|
+| **Plan file** (`docs/progress/plans/`) | Before starting any feature >5 steps or >2h | Steps with checkboxes, technical decisions, time estimates, success criteria |
+| **Session file** (`docs/progress/sessions/`) | After completing any significant session | What was built, key decisions with rationale, verification results, files changed |
+| **dev-notes.md** | Daily — append-only bullet log | One-liner per feature/fix, link to session file |
+| **PROGRESS.md** | After each session | Brief session entry in chronological list + execution log |
+| **Commit message** | Every commit | *What* changed and *why* (not how) |
+
+### When a Session File Is Required
+
+Create a session file whenever:
+- A feature plan was executed (session file = companion to plan file)
+- A significant bug was fixed with a non-obvious root cause
+- A maintenance or upgrade session touched many files
+- A decision was made that a future developer would need to understand
+
+Skip the session file for: single-file typo fixes, trivial dependency bumps, formatting-only changes.
+
+### The Decision Trail Habit
+
+Before closing a plan or session, ask: *"If I came back to this in 6 months, what would confuse me?"*
+
+Common things to capture:
+- Why a threshold is the value it is (e.g. "5 min auto-remove: matches the 120s disconnected threshold × 2.5, giving a visible grace period without requiring background jobs")
+- Why a pool cap is set where it is (e.g. "`max: 2` because serverless handles one request at a time; 2 allows parallel queries within a request without exhausting Supabase's per-connection limit")
+- What alternatives were rejected and why (e.g. "server-side auto-remove via cron was rejected because it requires background job infrastructure we don't have; host-side is acceptable since the host must be present for the game to run")
+
+### Maintenance Sessions
+
+Security and dependency upgrade sessions must record:
+- What drove the upgrade (CVE IDs or Dependabot alerts, not just "security")
+- What broke during the upgrade and how it was fixed
+- Any rules disabled or workarounds added, and why
+- What remains unresolved (e.g. transitive CVEs with no available fix)
+
 ## Key Patterns
 
 ### API Routes

--- a/docs/progress/PROGRESS.md
+++ b/docs/progress/PROGRESS.md
@@ -20,6 +20,24 @@ This document indexes all releases, completed work, and session notes. Use this 
 
 **Latest First** – Find detailed work notes by date:
 
+### 2026-05-09: Maintenance — Security Upgrades & Tooling ✅
+- **Focus**: Address 101 Dependabot security alerts, ESLint 10 migration, CI fixes, tooling improvements
+- **Deliverables**: 101→2 vulnerabilities fixed (Next 16.2.6, Prisma 7.8, ESLint 10, Vitest 4, Playwright 1.59), `.github/dependabot.yml` for automated updates, CI env fallbacks for Dependabot PRs, GitHub MCP package corrected, LF line ending enforcement, pg pool cap (EMAXCONN fix), Supavisor URL documented
+- **Status**: Complete — no regressions, lint clean, build passing
+- **File**: [sessions/2026-05-09-maintenance-security-tooling.md](sessions/2026-05-09-maintenance-security-tooling.md)
+
+### 2026-05-05: Player Kick & Auto-Remove ✅
+- **Focus**: Allow host to manually kick players; auto-remove players disconnected >5 minutes
+- **Deliverables**: `PlayerStatus.Removed` domain status + `removeFromGame()`, `RemovePlayerUseCase`, `DELETE /api/quiz/[quizId]/player/[playerId]`, `broadcastPlayerKicked()`, player redirect on kick with banner message, host kick button, auto-remove polling loop with `Set` dedup guard, rejoin support for removed players
+- **Status**: Complete — 413 tests passing, build passing, end-to-end manual verification
+- **File**: [sessions/2026-05-05-player-kick-auto-remove.md](sessions/2026-05-05-player-kick-auto-remove.md)
+
+### 2026-05-02: R6 Phase 3.5 — Game Lifecycle & UX Fixes ✅
+- **Focus**: Five post-Phase-3 bugs: quiz reset, host contextual buttons, player MC/TF UI, admin nav shortcuts, presence race condition
+- **Deliverables**: `Quiz.reset()` + `ResetQuizUseCase`, finish/restart mutations in `useHostQuizState`, player answer type switching, "Open Dashboard"/"Open Live View" admin links, heartbeat 30s→10s + `lastSeenAt` on answer submission
+- **Status**: Complete — 403 tests passing, build passing
+- **File**: [sessions/2026-05-02-r6-phase3.5-lifecycle-ux-fixes.md](sessions/2026-05-02-r6-phase3.5-lifecycle-ux-fixes.md)
+
 ### 2026-03-07: R6 Phase 2 — UI/UX Improvements ✅
 - **Focus**: Accessibility (a11y) fixes and responsive design for admin table
 - **Deliverables**: `aria-label` on icon-only buttons, `aria-live`/`role="status"` on dynamic messages, `role="timer"` on countdown, responsive admin quiz table (hidden columns at 375px), `role="alert"` on join form error (bonus), updated metadata description, admin email hidden on mobile
@@ -204,6 +222,27 @@ This document indexes all releases, completed work, and session notes. Use this 
 
 See [dev-notes.md](dev-notes.md) for the full execution log with timestamps.
 
+### 2026-05-09: Maintenance — Security Upgrades & Tooling
+- Security: 101→2 vulnerabilities (Next, Prisma, ESLint 10, Vitest 4, Playwright; yarn resolutions for transitive CVEs)
+- ESLint 10 flat config migration — removed FlatCompat bridge, disabled 2 false-positive rules for Next.js async patterns
+- `.github/dependabot.yml` added — weekly grouped updates for npm and GitHub Actions
+- CI: build job now uses env fallbacks so Dependabot PRs don't fail on missing secrets
+- Infrastructure: pg pool capped at `max: 2`; Supavisor port 6543 URL documented in `.env.example`
+- Tooling: GitHub MCP package corrected, `.gitattributes` LF enforcement, `.mcp.json` formatting
+- 10 routine Dependabot PRs merged (zod, tailwind, prettier, dotenv, tsx, tanstack, actions)
+- Session: [sessions/2026-05-09-maintenance-security-tooling.md](sessions/2026-05-09-maintenance-security-tooling.md)
+
+### 2026-05-05: Player Kick & Auto-Remove ✅
+- `PlayerStatus.Removed` + `Player.removeFromGame(reason)` domain method (soft delete, data preserved)
+- `RemovePlayerUseCase` — validates ownership, calls domain, saves; `AddPlayerUseCase` excludes `Removed` from name-conflict check (rejoin support)
+- `DELETE /api/quiz/[quizId]/player/[playerId]` with optional `reason` body
+- `broadcastPlayerKicked()` on private `player:{quizId}:{playerId}` channel
+- Player UI: `player:kicked` → redirect to `/join?kicked=true` with amber banner
+- Host UI: Kick button per row + auto-remove loop (5-min disconnected threshold, `Set` dedup guard)
+- `GetQuizStateUseCase` filters `Removed` players from `QuizDTO` (hotfix post-merge)
+- 413 tests passing, manual kick + rejoin verified
+- Session: [sessions/2026-05-05-player-kick-auto-remove.md](sessions/2026-05-05-player-kick-auto-remove.md)
+
 ### 2026-05-02: R6 Phase 3.5 — Game Lifecycle & UX Fixes ✅
 - **Step 1**: Quiz reset — `Quiz.reset()`, `ResetQuizUseCase`, `POST /api/admin/quizzes/[quizId]/reset` (6 new tests)
 - **Step 2**: Host dashboard contextual buttons — finish/restart mutations, `POST /api/quiz/[quizId]/finish`, status-aware button set
@@ -211,6 +250,7 @@ See [dev-notes.md](dev-notes.md) for the full execution log with timestamps.
 - **Step 4**: Admin dashboard/live view buttons — "Open Dashboard" (all statuses) + "Open Live View" (Active) on detail page and quiz list
 - **Step 5**: Presence fix — heartbeat interval 30s→10s (race with 30s connected threshold), answer submission refreshes `lastSeenAt`
 - 403 tests passing, `yarn build` succeeds
+- Session: [sessions/2026-05-02-r6-phase3.5-lifecycle-ux-fixes.md](sessions/2026-05-02-r6-phase3.5-lifecycle-ux-fixes.md)
 - Plan: [plans/2026-03-14-r6-phase3.5-lifecycle-ux-fixes.md](plans/2026-03-14-r6-phase3.5-lifecycle-ux-fixes.md)
 
 ### Previous (2026-03-08):
@@ -275,6 +315,13 @@ All R5 phases complete as of 2026-02-01. See [plan.md](../plan.md) for performan
 - [x] Presence fix: heartbeat interval reduced (30s→10s), answer submission refreshes `lastSeenAt`
 - **Plan:** [plans/2026-03-14-r6-phase3.5-lifecycle-ux-fixes.md](plans/2026-03-14-r6-phase3.5-lifecycle-ux-fixes.md)
 
+**Player Management (shipped 2026-05-05)** ✅
+- [x] Host kick button — removes any player at any time (lobby or active game)
+- [x] Auto-remove disconnected players after 5-minute threshold
+- [x] Kicked player receives realtime redirect + "removed from game" banner
+- [x] Removed players can rejoin using the same join code
+- **Plan:** [plans/2026-05-05-player-kick-and-auto-remove.md](plans/2026-05-05-player-kick-and-auto-remove.md)
+
 **Phase 4: Analytics & Observability**
 - [ ] PostHog analytics instrumentation
 - [ ] Structured logging with request IDs
@@ -310,6 +357,8 @@ See [file-ideas.md](file-ideas.md) for tracked follow-ups per file.
 - **Performance**: P95 latencies exceed targets; optimization path documented
 - **Testing**: E2E selector strict mode violations in some tests
 - **Security**: RLS not enabled on Prisma-managed tables (app uses server-side Prisma, not PostgREST)
+- **Dependencies**: 2 remaining Dependabot alerts with no available fix (transitive, low risk); Dependabot now runs weekly
+- **Infrastructure**: Supavisor (pgbouncer) URL on port 6543 is the correct production `DATABASE_URL` — see `.env.example`
 
 ---
 

--- a/docs/progress/dev-notes.md
+++ b/docs/progress/dev-notes.md
@@ -1,5 +1,17 @@
 # Dev Progress Log
 
+## 2026-05-09 (Maintenance: Security, Tooling, CI ✅)
+- **Security**: 101 Dependabot vulnerabilities → 2; bumped Next 16.2.6, Prisma 7.8, ESLint 10, Vitest 4, Playwright 1.59; added `resolutions` in `package.json` for transitive CVEs (minimatch, brace-expansion, flatted, picomatch, vite, postcss, @hono/node-server, js-yaml)
+- **ESLint 10**: Removed `FlatCompat` bridge (circular JSON error); native `eslint-config-next` flat export; disabled `react-hooks/error-boundaries` (false positive on Next.js async server components) and `react-hooks/set-state-in-effect` (legitimate derived-state patterns); fixed `use-presence.tsx` to add `sendHeartbeatRef` to deps
+- **Dependabot**: Added `.github/dependabot.yml` — weekly grouped npm updates + weekly GitHub Actions updates
+- **CI**: Added env fallbacks (`|| ''`) in build job so Dependabot PRs don't fail on missing secrets; bumped `setup-node` v4→v5
+- **GitHub MCP**: Corrected package name in `.mcp.json`/`.vscode/mcp.json`/`.claude/settings.local.json` (was non-existent `@anthropic-ai/claude-code`, now `@modelcontextprotocol/server-github`)
+- **LF endings**: `.gitattributes` `* text=auto eol=lf` + VS Code `files.eol: \n`
+- **pg pool cap**: `max: 2` on `PrismaPg` adapter; `.env.example` documents Supavisor URL (port 6543) as the primary EMAXCONN fix
+- **Prettier 3.8.3**: Reformatted affected files after bump
+- **10 routine Dependabot PRs merged**: zod, tailwind-merge, @tailwindcss/postcss, dotenv, tsx, vite-tsconfig-paths, tanstack group, actions/checkout v6, actions/setup-node v6
+- Session: [sessions/2026-05-09-maintenance-security-tooling.md](sessions/2026-05-09-maintenance-security-tooling.md)
+
 ## 2026-05-05 (Player Kick & Auto-Remove ✅)
 - **Soft removal via `Removed` status**: New `PlayerStatus.Removed` in domain + Prisma schema; `removeFromGame(reason)` method on Player entity
 - **RemovePlayerUseCase**: Application use case validates player + quiz ownership, calls domain method, saves. Rejoin support — `Removed` excluded from name-duplicate check in `AddPlayerUseCase`

--- a/docs/progress/sessions/2026-05-02-r6-phase3.5-lifecycle-ux-fixes.md
+++ b/docs/progress/sessions/2026-05-02-r6-phase3.5-lifecycle-ux-fixes.md
@@ -1,0 +1,103 @@
+# R6 Phase 3.5 — Game Lifecycle & UX Fixes
+
+**Date:** 2026-05-02 to 2026-05-03
+**Status:** ✅ Complete
+**Branch:** `fix/game-lifecycle-ux`
+**Plan:** [plans/2026-03-14-r6-phase3.5-lifecycle-ux-fixes.md](../plans/2026-03-14-r6-phase3.5-lifecycle-ux-fixes.md)
+
+---
+
+## Summary
+
+Five bugs and UX gaps discovered during manual testing after R6 Phase 3 shipped. All five were fixed across this session. No new infrastructure was required — all changes live within existing layers.
+
+---
+
+## What Was Fixed
+
+### Step 1 — Quiz Reset (Domain + Use Case + API)
+
+**Problem:** A quiz in `Completed` status had no path back to a startable state. Only delete was available.
+
+**Solution:**
+- Added `Quiz.reset()` domain method: transitions `Completed` or `Active` → `Pending`, clears `startedAt`/`endedAt`/`currentQuestionIndex`, unlocks questions, wipes accumulated answers
+- Created `ResetQuizUseCase` calling `quiz.reset()` and saving
+- Added `POST /api/admin/quizzes/[quizId]/reset` route
+- Also added `POST /api/quiz/[quizId]/reset` for host-side restart flow
+- 6 new tests (domain + use case)
+
+**Decision:** Reset clears all player answer state so the quiz starts fresh. This was preferred over a "soft reset" that preserved history, because the host replaying a quiz wants a clean slate. Answer history is not critical enough to justify the added complexity of partial resets.
+
+### Step 2 — Host Dashboard: Contextual Action Buttons
+
+**Problem:** "Resume Quiz" button showed for all `Active` quizzes and threw a 400 on press. No "Finish" or "Restart" option existed.
+
+**Solution:**
+- Pre-flight: fixed `EndQuizUseCase` — removed dead `getLeaderboard()` call, return type changed to `void`
+- New `POST /api/quiz/[quizId]/finish` route (ends quiz, broadcasts state)
+- Added `finishQuiz` and `restartQuiz` mutations to `useHostQuizState`
+- Host dashboard now shows status-conditional button set:
+  - `Pending` → "Start quiz"
+  - `Active` → "Open Live View" + "Finish quiz"
+  - `Completed` → "Restart quiz"
+
+**Decision:** Keep all logic in the presentation layer (hook mutations + conditional rendering). No new domain methods needed — the existing `endQuiz` + `reset` use cases cover both actions.
+
+### Step 3 — Player Answer UI: Adapt to Question Type
+
+**Problem:** The player answer pad showed the same text input regardless of question type. MC and TF questions should show option buttons, not a free-text field.
+
+**Solution:**
+- Read `currentQuestion.type` and `currentQuestion.options` from the question DTO
+- Conditional rendering: `MultipleChoice` | `TrueFalse` → option buttons; everything else → text input
+- Selected option is highlighted; submission works identically on both paths
+
+### Step 4 — Admin Quiz Page: Navigation Shortcuts
+
+**Problem:** From the admin quiz detail page, there was no direct link to the host dashboard or live game view. Hosts had to navigate to `/host` manually.
+
+**Solution:**
+- Added "Open Dashboard" button (visible for all statuses) linking to `/quiz/[quizId]`
+- Added "Open Live View" button (visible only for `Active` quizzes) linking to `/quiz/[quizId]/live`
+- Same two buttons added as icon links in the quiz list table rows
+
+### Step 5 — Presence: Fix Away → Disconnected Regression
+
+**Problem:** Players who were actively answering questions still cycled through `away → disconnected` in the host dashboard. Status never reverted to `connected` after a heartbeat or action.
+
+**Root cause:** Heartbeat interval was 30 seconds — exactly equal to the `connected` threshold (< 30s since last seen). Any timing variance caused a player to fall into the `away` bucket even if they had just been active. Additionally, submitting an answer never touched `lastSeenAt`, so a player who answered and then sat still would drift to `away` even though they were clearly present.
+
+**Fix:**
+- Reduced heartbeat interval from 30s to 10s (`usePresence`) so it fires 3× within the connected window
+- Updated `SubmitAnswerUseCase` to set `player.lastSeenAt = new Date()` on every answer submission
+- Added test: verifies `lastSeenAt` is updated when `SubmitAnswerUseCase.execute()` is called
+
+**Decision:** Fix the underlying heartbeat timing rather than patch the display layer. A display-only fix would have masked the root cause and left players drifting incorrectly in any slow-network scenario.
+
+---
+
+## Key Commits
+
+| Hash | Message |
+|------|---------|
+| `cf8217f` | fix: R6 Phase 3.5 Step 5 — presence race condition and stale lastSeenAt |
+| `71a6434` | fix: update quiz reset functionality and improve error handling |
+
+---
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| `yarn test` | ✅ 403 tests passing (1 skipped, pre-existing) |
+| `yarn build` | ✅ Compilation and type-checking pass |
+| `yarn lint` | ✅ 0 errors |
+| Playwright spot-check | ⚠️ Deferred (noted in plan) |
+
+---
+
+## What Was NOT Changed
+
+- PresenceTracker / PresenceMonitor service — heartbeat fix was in `usePresence` hook only
+- Domain model for Player (presence is infrastructure concern, not domain)
+- Any E2E tests — all changes verified via unit tests and manual inspection

--- a/docs/progress/sessions/2026-05-05-player-kick-auto-remove.md
+++ b/docs/progress/sessions/2026-05-05-player-kick-auto-remove.md
@@ -1,0 +1,133 @@
+# Player Kick & Auto-Remove
+
+**Date:** 2026-05-05
+**Status:** ✅ Complete
+**Branch:** `feat/kick-player`
+**Plan:** [plans/2026-05-05-player-kick-and-auto-remove.md](../plans/2026-05-05-player-kick-and-auto-remove.md)
+
+---
+
+## Summary
+
+Implemented the full player removal system: a host can manually kick any player at any time, and the system auto-removes players who have been disconnected for 5+ minutes while the host's browser is open. Kicked/removed players receive an immediate realtime notification and are redirected to the join page.
+
+Final state: 413 tests passing, lint clean, build passing, manual kick flow verified.
+
+---
+
+## What Was Built
+
+### Domain — `PlayerStatus.Removed` + `removeFromGame()`
+
+Added `Removed = 'Removed'` to the `PlayerStatus` enum on the `Player` entity. Added `removeFromGame(reason: 'kicked' | 'timeout'): void` which:
+- Throws if the player is already `Removed` (idempotency guard)
+- Sets `this.status = PlayerStatus.Removed` and stores the reason
+
+**Decision: Soft delete via `Removed` status, not hard delete.** Keeps answer history and scores intact for audit purposes. Simpler than cascade-deleting in Prisma. A `Removed` player is invisible to the game but the DB row remains.
+
+### Infrastructure — Prisma schema
+
+Added `Removed` to the `PlayerStatus` enum in `schema.prisma`. Migration: `add_removed_player_status`. Required `yarn prisma:generate` to regenerate the client.
+
+### Application — `RemovePlayerUseCase`
+
+New use case at `src/application/use-cases/remove-player.use-case.ts`:
+1. Find player by `playerId` — throw if missing
+2. Validate `player.quizId === quizId` — throw `'Player not found'` if mismatch (prevents cross-quiz removals)
+3. Call `player.removeFromGame(reason)`
+4. Save via `playerRepository.save(player)`
+
+Also patched `AddPlayerUseCase` name-duplicate check to exclude `Removed` players, so a removed player can rejoin with the same name under the same join code and get a fresh `playerId`.
+
+`GetQuizStateUseCase` updated to filter out `Removed` players before mapping to `QuizDTO` — they no longer appear in the lobby, question view, or results.
+
+### Realtime — `broadcastPlayerKicked()`
+
+Added to `src/infrastructure/realtime/broadcast-player-events.ts`. Sends a `player:kicked` event on the private `player:{quizId}:{playerId}` channel with payload `{ reason: 'kicked' | 'timeout' }`.
+
+**Decision: Private per-player channel** (not the quiz-wide channel). Only the affected player receives the event. Reuses the existing `player:{quizId}:{playerId}` pattern established for `answer:ack` in R5.
+
+### API — `DELETE /api/quiz/[quizId]/player/[playerId]`
+
+Added `DELETE` export to the existing player route file. Accepts optional `{ reason?: 'kicked' | 'timeout' }` body (defaults to `'kicked'`). Calls `playerService.removePlayer()` then `broadcastPlayerKicked()`.
+
+### Player UI — `player:kicked` handling
+
+`usePlayerSession` now listens on the private channel for `player:kicked`. On receipt: redirects to `/join?kicked=true`.
+
+The join page reads `?kicked=true` from `searchParams` and shows an amber banner: "You were removed from the game by the host." The banner is display-only — no state stored; navigating away clears it naturally.
+
+### Host UI — Kick button + auto-remove
+
+`useHostQuizPlayers` exposes:
+- `kickPlayer(playerId)` — mutation calling `DELETE /api/quiz/{quizId}/player/{playerId}` with `reason: 'kicked'`; invalidates the player status query on success
+- `isKicking: boolean` — pending state for button feedback
+
+Auto-removal loop added to the polling `onSuccess` callback:
+- Threshold: 5 minutes of `connectionStatus === 'disconnected'`
+- Guarded by a `Set` ref (`autoRemovedRef`) to prevent duplicate DELETE calls across poll cycles
+- On trigger: calls the same removal mutation with `reason: 'timeout'`
+
+`PlayerListWithStatus` component gained a "Kick" button per player row (destructive variant, disabled while `isKicking`).
+
+**Decision: Auto-remove is host-side (polling loop), not server-side (cron/background job).** Avoids background job infrastructure. Acceptable trade-off: auto-removal only runs while the host's browser tab is open — but a host must be present for the game to run anyway.
+
+**Decision: `Set` ref for auto-remove dedup.** A plain `useRef<Set<string>>` persists across re-renders without triggering them. Prevents the 5s polling loop from calling DELETE multiple times on the same player before the query invalidation removes them from the list.
+
+---
+
+## Key Commits
+
+| Hash | Message |
+|------|---------|
+| `cccd885` | feat: implement player kick and auto-remove functionality |
+| `2eff320` | feat: add Removed player status and removeFromGame domain method |
+| `39e46d7` | feat: application layer - RemovePlayerUseCase, rejoin fix, Removed filter |
+| `bb6961f` | feat: realtime broadcast and DELETE API for player removal |
+| `ddf74f0` | feat: player UI - handle player:kicked event and show removal message |
+| `2b2fdf4` | feat: host UI - auto-remove disconnected players and kick button |
+| `c197f8c` | fix: add Removed to PlayerStatusDTO and fix next-env.d.ts quotes |
+| `76c0314` | fix: exclude Removed players from quiz state DTO |
+
+---
+
+## Files Changed
+
+### New
+| File | Purpose |
+|------|---------|
+| `src/application/use-cases/remove-player.use-case.ts` | Core removal logic |
+| `src/tests/application/use-cases/remove-player.use-case.test.ts` | Use case tests |
+
+### Modified (key files)
+| File | Change |
+|------|--------|
+| `src/domain/entities/player.ts` | `Removed` status + `removeFromGame()` |
+| `src/infrastructure/database/prisma/schema.prisma` | `Removed` added to `PlayerStatus` enum |
+| `src/application/use-cases/add-player.use-case.ts` | Exclude `Removed` from name conflict check |
+| `src/application/use-cases/get-quiz-state.use-case.ts` | Filter `Removed` players from QuizDTO |
+| `src/infrastructure/realtime/broadcast-player-events.ts` | `broadcastPlayerKicked()` |
+| `src/app/api/quiz/[quizId]/player/[playerId]/route.ts` | `DELETE` handler |
+| `src/hooks/use-player-session.ts` | `player:kicked` event handler + redirect |
+| `src/hooks/use-host-quiz-players.ts` | Auto-remove loop + `kickPlayer` mutation |
+| `src/components/host/player-list-with-status.tsx` | Kick button per row |
+
+---
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| `yarn test` | ✅ 413 tests passing |
+| `yarn build` | ✅ Passes |
+| `yarn lint` | ✅ 0 errors |
+| Manual kick flow | ✅ Verified end-to-end in browser |
+| Rejoin after kick | ✅ Verified — removed player can rejoin with same join code |
+
+---
+
+## Post-merge Hotfix
+
+After the initial PR merge, `GetQuizStateUseCase` still exposed `Removed` players in the quiz state DTO because the filter was missing. Fixed in `76c0314` with a new test covering the filter behaviour.
+
+Similarly, `PlayerStatusDTO` was missing the `Removed` variant — fixed in `c197f8c`.

--- a/docs/progress/sessions/2026-05-09-maintenance-security-tooling.md
+++ b/docs/progress/sessions/2026-05-09-maintenance-security-tooling.md
@@ -1,0 +1,160 @@
+# Maintenance & Security — Dependency Upgrades, Tooling, CI
+
+**Date:** 2026-05-09
+**Status:** ✅ Complete
+**Type:** Maintenance (no feature changes)
+
+---
+
+## Summary
+
+A focused maintenance day addressing 101 Dependabot security vulnerabilities (reduced to 2), migrating ESLint to v10 flat config, setting up automated dependency tracking, and fixing several tooling issues discovered in the process. No game logic was changed.
+
+---
+
+## What Was Done
+
+### 1. Security Dependency Upgrades (101 → 2 vulnerabilities)
+
+**Problem:** Dependabot reported 101 security alerts across direct and transitive dependencies.
+
+**Upgrades applied:**
+| Package | Before | After |
+|---------|--------|-------|
+| `next` | 16.1.5 | 16.2.6 |
+| `@prisma/client`, `@prisma/adapter-pg`, `prisma` | ^7.x | ^7.8.0 |
+| `eslint` | 9.x | 10.3.0 |
+| `eslint-plugin-react-hooks` | ^5.x | ^7.1.1 |
+| `vitest` | 3.x | ^4.1.5 |
+| `@playwright/test` | ^1.5x | ^1.59.1 |
+| `postcss` | previous | ^8.5.14 |
+
+**Yarn resolutions added** for transitive CVEs (packages not directly depended on):
+- `minimatch`, `brace-expansion`, `flatted`, `picomatch`, `vite`, `postcss`, `@hono/node-server`, `js-yaml`
+
+Remaining 2 vulnerabilities: transitive deps with no available fix yet — tracked and accepted.
+
+**Decision: Use `resolutions` for transitive CVEs** rather than waiting for upstream packages to update. This is the standard Yarn approach for audited transitive vulnerabilities where the consuming package hasn't released a fix.
+
+### 2. ESLint 10 Flat Config Migration
+
+**Problem:** Upgrading ESLint 9→10 broke the existing config which used `FlatCompat` (the compatibility bridge from ESLint 8 class-style configs). ESLint 10 dropped `FlatCompat`, causing a circular JSON serialization error on startup.
+
+**Solution:**
+- Removed `FlatCompat` bridge entirely from `eslint.config.mjs`
+- Switched to native `eslint-config-next` flat config export
+- Disabled two rules that produced false positives on this codebase:
+  - `react-hooks/error-boundaries` — false positive on Next.js async server components
+  - `react-hooks/set-state-in-effect` — legitimate derived-state sync patterns used throughout hooks
+
+**Additional fix:** `use-presence.tsx` needed `sendHeartbeatRef` added to dependency arrays to satisfy the stricter `react-hooks/immutability` rule introduced in the v7 plugin.
+
+**Decision: Disable specific false-positive rules rather than suppress per-line.** File-level suppressions create noise and can hide real issues. The two disabled rules have known false-positive patterns in Next.js 15 async component and hook patterns. Noted in a comment in `eslint.config.mjs`.
+
+### 3. Automated Dependency Updates — `.github/dependabot.yml`
+
+Added Dependabot configuration for:
+- npm dependencies (weekly, grouped by ecosystem: production/dev/testing/styling)
+- GitHub Actions (weekly, auto-merge patch updates)
+
+**Decision: Group Dependabot PRs by category** (not one PR per package). Reduces PR noise while keeping security updates fast. Grouping: `supabase`, `eslint`, `tanstack`, `tailwind`, `vitest`, `playwright` — each as a named group.
+
+### 4. CI Fix — Build Job Env Fallbacks for Dependabot PRs
+
+**Problem:** The CI build job required `DATABASE_URL`, `NEXT_PUBLIC_SUPABASE_URL`, and other env vars. Dependabot PRs run without repository secrets, causing the build to fail with "missing environment variable" errors.
+
+**Fix:** Added fallback values (`|| ''` or `|| 'http://localhost'`) to all env var references in `.github/workflows/ci.yml` for the build job. The build step only needs these vars for type-checking and bundling — it doesn't connect to any live database.
+
+Also bumped `actions/setup-node` from v4 → v5 in the CI workflow.
+
+### 5. GitHub MCP Server Package Fix
+
+**Problem:** `.mcp.json` referenced a non-existent `@anthropic-ai/claude-code` GitHub MCP package name. The correct package is `@modelcontextprotocol/server-github`.
+
+**Fix:** Replaced the incorrect package in `.mcp.json`, `.vscode/mcp.json`, and `.claude/settings.local.json`. Also reformatted the args array in `.mcp.json` for readability (one arg per line).
+
+### 6. LF Line Ending Enforcement
+
+**Problem:** Mixed CRLF/LF line endings were appearing in files edited on Windows or via certain tools, causing noisy diffs.
+
+**Fix:**
+- Added `.gitattributes` with `* text=auto eol=lf`
+- Updated `.vscode/settings.json` with `"files.eol": "\n"`
+
+### 7. Tooling Dependency Bumps (Dependabot PRs — merged same day)
+
+Merged 10 Dependabot PRs for non-security routine updates:
+
+| Package | Change |
+|---------|--------|
+| `zod` | 4.3.6 → 4.4.3 |
+| `tailwind-merge` | 3.2.0 → 3.5.0 |
+| `@tailwindcss/postcss` | 4.1.3 → 4.3.0 |
+| `prettier` | 3.5.3 → 3.8.3 |
+| `dotenv` | 17.2.3 → 17.4.2 |
+| `tsx` | 4.20.6 → 4.21.0 |
+| `vite-tsconfig-paths` | patch bump |
+| TanStack group | patch bumps |
+| `actions/checkout` | v4 → v6 |
+| `actions/setup-node` | v5 → v6 |
+
+**Note:** prettier 3.8.3 changed formatting for some edge cases. A follow-up commit (`884f0da`) reformatted affected files to match the new output.
+
+### 8. Pg Pool Cap — EMAXCONN Prevention
+
+**Problem:** Under load, the Prisma pg adapter was exhausting Supabase's connection limit, producing `EMAXCONN` errors.
+
+**Fix:** Set `max: 2` on the `PrismaPg` adapter pool in `src/infrastructure/database/prisma/client.ts`. In serverless (Vercel), each lambda instance handles one request at a time, so 2 connections per instance is sufficient with headroom.
+
+Also documented the correct `DATABASE_URL` pattern in `.env.example`: Supabase's Supavisor (pgbouncer) URL uses **port 6543** (not 5432). Switching to port 6543 routes connections through the pooler rather than directly to Postgres — this is the primary fix for connection exhaustion in production.
+
+**Decision: Cap at 2, not 1.** A cap of 1 would serialize all queries within a single request that makes parallel Prisma calls. 2 provides parallelism while staying well within per-instance limits. The Supavisor URL change is the real production fix; the pool cap is a defence-in-depth guard.
+
+### 9. Documentation — Prefer gh CLI Over GitHub MCP
+
+Updated `.github/copilot-instructions.md` to clarify that the `gh` CLI should be used for all GitHub interactions (PRs, issues, comments, CI checks) rather than the GitHub MCP tools. The MCP tools have higher latency and less reliable output formatting for structured operations.
+
+---
+
+## Key Commits
+
+| Hash | Message |
+|------|---------|
+| `ea6bc82` | fix: address Dependabot security vulnerabilities (101 → 2) |
+| `c9cd998` | fix: enforce LF line endings via .gitattributes and VS Code settings |
+| `edeb25c` | fix: replace non-existent github MCP package with correct one |
+| `4a00411` | fix: format args in .mcp.json for better readability |
+| `844829a` | ci: fix build job env fallbacks for Dependabot PRs, bump setup-node to v5 |
+| `8b4e336` | fix: cap pg pool size to prevent EMAXCONN on Supabase |
+| `76c0314` | fix: exclude Removed players from quiz state DTO |
+| `884f0da` | fix: format files for prettier 3.8.3 compatibility |
+| `305edf2` | docs: prefer gh CLI over GitHub MCP for PR/issue interactions |
+| + 10× | build(deps): Dependabot routine bumps |
+
+---
+
+## Files Changed (key files)
+
+| File | Change |
+|------|--------|
+| `package.json` | Major version bumps, resolutions for transitive CVEs |
+| `yarn.lock` | Full regeneration |
+| `eslint.config.mjs` | ESLint 10 flat config, removed FlatCompat |
+| `.github/dependabot.yml` | New — automated update config |
+| `.github/workflows/ci.yml` | Env fallbacks, setup-node v5 |
+| `src/infrastructure/database/prisma/client.ts` | `max: 2` pool cap |
+| `.env.example` | Document Supavisor URL (port 6543) |
+| `.gitattributes` | LF enforcement |
+| `.mcp.json` / `.vscode/mcp.json` | Correct GitHub MCP package |
+| `src/hooks/use-presence.tsx` | `sendHeartbeatRef` to satisfy ESLint 10 hooks rule |
+
+---
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| `yarn test` | ✅ All tests passing (no regressions from upgrades) |
+| `yarn build` | ✅ Passes with ESLint 10 flat config |
+| `yarn lint` | ✅ 0 errors |
+| Dependabot alerts | ✅ 101 → 2 (2 remaining have no available fix) |


### PR DESCRIPTION
Add three session files covering work since the last log entry:
- 2026-05-02: R6 Phase 3.5 lifecycle/UX fixes (quiz reset, host buttons,
  player MC/TF UI, admin nav links, presence race fix)
- 2026-05-05: Player kick & auto-remove feature (full 11-step implementation)
- 2026-05-09: Maintenance day (101→2 security vulns, ESLint 10 migration,
  dependabot.yml, CI env fallbacks, pg pool cap, tooling fixes)

Update PROGRESS.md and dev-notes.md with entries for all three sessions.

Add "Documentation Practices" section to CLAUDE.md: decision logging
format, what-goes-where table, the decision trail habit, and guidance
for maintenance session documentation.

https://claude.ai/code/session_01JjBf4qBXskmrWeQeTRM8qc