### PR TITLE
fix: presence heartbeat resilience (stop swallowing DB-write failures)

### DIFF
--- a/docs/progress/plans/2026-07-05-presence-heartbeat-resilience-design.md
+++ b/docs/progress/plans/2026-07-05-presence-heartbeat-resilience-design.md
@@ -1,0 +1,77 @@
+# Presence Heartbeat Resilience — Design Spec
+
+**Status:** 📋 Approved, ready for implementation plan
+**Related:** `fix/host-leaderboard-realtime-update` (bug #1, already fixed/committed on a separate branch)
+
+## Background
+
+During a production 2-player game session:
+1. Supabase's Supavisor pooler hit its hard-coded max client connections (200 on the current compute tier), rejecting requests project-wide (bug #3).
+2. Players' connection status flipped `connected → away → disconnected` very quickly even though their browser tab stayed open and fully connected, and were eventually auto-removed (bug #2).
+
+**Root cause of bug #2**, found by reading the actual heartbeat code path:
+
+- The host's player list derives connection status **purely from a DB column** (`Player.lastSeenAt`), via `ConnectionStatus.fromLastSeenAt` (`src/domain/value-objects/connection-status.ts`): connected ≤30s, away ≤120s, disconnected beyond that.
+- The player's browser writes that column via a heartbeat: `usePresence` (`src/hooks/use-presence.tsx`) calls `tracker.track()` (Supabase Realtime presence, websocket-based, no Postgres involved) and `persistPresence()` (a `POST /api/quiz/[quizId]/player/[playerId]/presence` call that writes `lastSeenAt`) every 10 seconds.
+- `usePresence` already has a well-built resilience mechanism: `sendHeartbeat` wraps both calls in a try/catch, retries failures with exponential backoff (1s/2s/4s/8s/8s over 5 attempts), and calls `onConnectionError` once the circuit trips. `useReconnection` (`src/hooks/use-reconnection.ts`) wires that into a `connected/disconnected/reconnecting/failed` state machine, and `player-session-screen.tsx` already renders a `ConnectionStatusBanner` off that state, with `persistToDatabase: true` passed through.
+- **The one bug**: `persistPresence()` catches and swallows its own errors internally (dev-only `console.warn`, no rethrow). A DB-write failure therefore never reaches `sendHeartbeat`'s `try/catch`, so the entire retry/backoff/circuit-breaker/banner chain — which already exists and is otherwise correct — never activates for DB failures. Only Realtime presence-channel failures can trip it. The player's UI shows nothing wrong while the DB's view of them silently goes stale, ages through away → disconnected, and eventually triggers host-side auto-removal (`src/hooks/use-host-quiz-players.ts`, 5-minute threshold).
+
+This connects to bug #3: the heartbeat fires every 10s per player as its own serverless request, each a candidate for a fresh Prisma pool on a cold Vercel lambda instance — a plausible contributor to pool pressure, not just a victim of it.
+
+## Scope
+
+**In scope:**
+1. Fix `persistPresence()` to propagate errors into the existing retry/backoff/circuit-breaker instead of swallowing them (bug #2's actual fix).
+2. Decouple the DB *persist* cadence from the Realtime *track* cadence, and add jitter, to reduce steady-state presence-related DB writes and desynchronize concurrent players' writes.
+3. Slow the heartbeat cadence once the circuit breaker is open (sustained failures), so a real outage doesn't have every player hammering the DB every 10s for the duration of the outage — this is the piece most directly aimed at reducing bug #3's load contribution during an incident.
+4. Add production-safe logging for heartbeat persistence failures (today it's dev-only `console.warn`), so a future incident like this leaves an immediate trace instead of requiring a multi-step investigation to even see it happened.
+
+**Out of scope (non-goals):**
+- No change to the Realtime presence-track protocol/websocket behavior.
+- No server-side presence aggregator / cron-based batching (considered as "Approach 2" and deferred — would eliminate per-client heartbeat DB writes entirely, but needs new always-on infra Vercel's serverless model doesn't naturally provide, and is disproportionate to a 2-player-triggered incident).
+- No change to `usePlayerSession`'s 5s quiz-state poll, even though it's a larger steady-state DB load source than the presence heartbeat — worth a future look, not this fix.
+- No Supabase compute-tier / infrastructure changes.
+- No changes to `useReconnection`, `ConnectionStatusBanner`, or any host-side hook — they are already correct and will simply start receiving real signals once `persistPresence` stops swallowing errors.
+
+## Architecture
+
+Single hook, no cross-layer changes — this is presentation-layer only (domain thresholds are read, not modified).
+
+```
+src/hooks/use-presence.tsx              — core fix: error propagation + cadence changes
+src/tests/hooks/use-presence.test.ts    — + real behavioral tests (fake timers)
+```
+
+## Design
+
+### Behavior change
+
+**Before:** DB write fails → error is swallowed inside `persistPresence` → `sendHeartbeat` believes the heartbeat succeeded → player UI shows nothing wrong → host, reading only the stale `lastSeenAt` column, ages the player through away → disconnected → removed with zero player-side feedback and no way for the player to know or intervene.
+
+**After:** DB write fails → propagates to `sendHeartbeat`'s catch → existing fast retries (1/2/4/8/8s, unchanged, ~23s total) → if still failing, existing `onConnectionError` fires → player sees the existing `ConnectionStatusBanner` ("Connection lost. Trying to reconnect...") → heartbeat cadence itself slows while the circuit is open (proposed: back off to a longer flat interval, e.g. 30s, instead of continuing at 10s) → first subsequent success resumes normal cadence and fires the existing `onReconnected` path.
+
+**Steady state (no failures):** `tracker.track()` (websocket, cheap, no Postgres) continues every 10s as today. `persistPresence()` (the DB write) moves to a longer, jittered interval — proposed 20s ± ~5s random jitter per mount — comfortably under the 30s "connected" threshold with margin, cutting DB round-trips roughly in half versus today's 10s cadence, and desynchronizing multiple players' writes so they don't cluster into simultaneous bursts.
+
+### Error handling / observability
+- `persistPresence()` re-throws instead of catching-and-swallowing.
+- Add a production-safe log call (not gated to `NODE_ENV === 'development'`) when a heartbeat persistence attempt fails, so this failure mode is visible in production logs going forward.
+- No new error types — continues to use the `Error` thrown from the existing fetch failure / non-ok-response path.
+
+### Testing
+- Extend `src/tests/hooks/use-presence.test.ts` with fake-timer-driven behavioral tests covering: a failing `persistPresence` increments `failureCount` and eventually calls `onConnectionError`; the heartbeat cadence slows once the circuit is open; cadence and `failureCount` reset on the next success.
+- No changes needed to domain (`connection-status.ts`) or use-case (`get-player-connection-status`) tests — their logic is unchanged, only the reliability of what feeds them.
+- Manual verification: same Playwright approach used for bug #1 — join as a player, simulate `/presence` route failures (temporarily returning a 500, or throttling), and confirm the player sees the reconnecting banner while the host's status view behaves sensibly, then confirm recovery once the route succeeds again.
+
+### Risk / rollout
+Low risk. The resilience half only changes error propagation in one function. The cadence half only changes timing, not logic, and stays within the existing domain thresholds (30s/120s) with margin. No feature flag needed: the worst-case failure mode if something is subtly wrong is "no worse than today's silent-failure behavior."
+
+## Decision Log
+
+**Decision: propagate errors instead of building a new resilience system**
+Considered building new failure-detection machinery for DB persistence specifically. Rejected because `usePresence`/`useReconnection` already implement a complete, correct retry/backoff/circuit-breaker/banner chain — it's just never triggered for this failure mode. Re-throwing from `persistPresence` reuses all of it for free and is the smallest possible fix.
+
+**Decision: decouple persist cadence from track cadence rather than slowing both**
+`tracker.track()` is a websocket call with no Postgres cost; only `persistPresence()` contributes to pool pressure. Slowing both would unnecessarily reduce Realtime presence responsiveness (multiplayer join/leave detection) to save DB load that only the persist call actually causes.
+
+**Decision: defer server-side presence aggregation (Approach 2)**
+Would remove per-client heartbeat DB writes entirely by having one server-side process read Realtime's own presence state and batch-write `lastSeenAt`. Rejected for this round: Vercel's serverless model has no natural home for a long-lived background process (would need a Vercel Cron function or separate worker — new infra, new failure modes), and it doesn't address bug #2 by itself since the honest-failure-surfacing work is still needed regardless. Revisit if player counts grow well beyond a handful per game.

--- a/docs/progress/plans/2026-07-05-presence-heartbeat-resilience-design.md
+++ b/docs/progress/plans/2026-07-05-presence-heartbeat-resilience-design.md
@@ -1,6 +1,6 @@
 # Presence Heartbeat Resilience — Design Spec
 
-**Status:** 📋 Approved, ready for implementation plan
+**Status:** ✅ Complete — merged via [PR #58](https://github.com/Banych/bobrquiz/pull/58)
 **Related:** `fix/host-leaderboard-realtime-update` (bug #1, already fixed/committed on a separate branch)
 
 ## Background

--- a/docs/progress/plans/2026-07-05-presence-heartbeat-resilience-design.md
+++ b/docs/progress/plans/2026-07-05-presence-heartbeat-resilience-design.md
@@ -75,3 +75,6 @@ Considered building new failure-detection machinery for DB persistence specifica
 
 **Decision: defer server-side presence aggregation (Approach 2)**
 Would remove per-client heartbeat DB writes entirely by having one server-side process read Realtime's own presence state and batch-write `lastSeenAt`. Rejected for this round: Vercel's serverless model has no natural home for a long-lived background process (would need a Vercel Cron function or separate worker — new infra, new failure modes), and it doesn't address bug #2 by itself since the honest-failure-surfacing work is still needed regardless. Revisit if player counts grow well beyond a handful per game.
+
+**Decision: independent per-loop failure streaks, not a single shared counter**
+The initial implementation shared one `failureCount` across both the track and persist loops. Final review caught that this let a healthy track loop (websocket, succeeds every 10s) silently reset a failing persist loop's streak every cycle — meaning persist failures could never reach `maxRetryAttempts` and the circuit breaker would never trip for the exact DB-outage scenario this fix targets. Fixed by giving each loop its own failure count, tripping the circuit when either reaches the threshold and clearing it only once both have recovered.

--- a/docs/progress/plans/2026-07-05-presence-heartbeat-resilience-implementation.md
+++ b/docs/progress/plans/2026-07-05-presence-heartbeat-resilience-implementation.md
@@ -1,0 +1,915 @@
+# Presence Heartbeat Resilience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the presence heartbeat from silently swallowing DB-write failures (which currently lets a fully-connected player be marked away/disconnected/removed with zero feedback), and reduce the heartbeat's contribution to Supabase pool connection pressure.
+
+**Architecture:** Extract the retry/backoff/circuit-breaker/scheduling logic that currently lives inline in `usePresence` into a standalone, framework-agnostic `createPresenceHeartbeatController` factory in `src/lib/`, matching this repo's existing `src/lib/debounce-broadcast.ts` pattern. This makes the exact timing/failure logic that caused the bug unit-testable with `vi.useFakeTimers()` — this repo has no `jsdom`/`renderHook` infra, so hook-level tests here are type-contract-only and cannot catch this class of bug. `use-presence.tsx` becomes a thin React wrapper around the controller; its public API (`UsePresenceOptions`/`UsePresenceReturn`) is unchanged, so `useReconnection` and all consumers need zero changes.
+
+**Tech Stack:** TypeScript, React 19 hooks, Vitest (`vi.useFakeTimers()`, `vi.advanceTimersByTimeAsync()`), no new dependencies.
+
+## Global Constraints
+
+- Persist cadence (base + jitter) must stay comfortably under `CONNECTED_THRESHOLD_MS` (30s, defined in `src/domain/value-objects/connection-status.ts`) — do not change that domain constant.
+- No new npm dependencies (no `jsdom`, no `@testing-library/react`) — stay within this repo's existing test-without-rendering convention for hooks.
+- No changes to `useReconnection`, `ConnectionStatusBanner`, `connection-status.ts`, or any host-side hook — they are already correct.
+- `console.warn` on heartbeat failure must fire unconditionally (not gated to `NODE_ENV === 'development'`) so production incidents leave a log trace.
+- Follow this repo's `src/lib/` convention: factory function returning a plain object (not a class), JSDoc on the exported function.
+
+---
+
+### Task 1: `PresenceHeartbeatController` — core scheduling/retry/circuit-breaker logic
+
+**Files:**
+- Create: `src/lib/presence-heartbeat-controller.ts`
+- Test: `src/tests/lib/presence-heartbeat-controller.test.ts`
+
+**Interfaces:**
+- Produces: `createPresenceHeartbeatController(track: () => Promise<void>, persist: () => Promise<void>, callbacks: PresenceHeartbeatCallbacks, config?: PresenceHeartbeatConfig): PresenceHeartbeatController`
+  - `PresenceHeartbeatCallbacks = { onFailureCountChange: (count: number) => void; onSuccess: (timestampIso: string) => void; onConnectionError: () => void; onReconnected: () => void }`
+  - `PresenceHeartbeatConfig = { trackIntervalMs: number; persistIntervalMs: number; persistJitterMs: number; circuitOpenIntervalMs: number; maxRetryAttempts: number; retryDelaysMs: number[] }`
+  - `DEFAULT_PRESENCE_HEARTBEAT_CONFIG: PresenceHeartbeatConfig` — the production values.
+  - `PresenceHeartbeatController = { start: (options: { persistEnabled: boolean }) => void; sendImmediate: () => Promise<void>; stop: () => void; getFailureCount: () => number }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/tests/lib/presence-heartbeat-controller.test.ts`:
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createPresenceHeartbeatController,
+  DEFAULT_PRESENCE_HEARTBEAT_CONFIG,
+  type PresenceHeartbeatCallbacks,
+  type PresenceHeartbeatConfig,
+} from '@lib/presence-heartbeat-controller';
+
+const FAST_CONFIG: PresenceHeartbeatConfig = {
+  trackIntervalMs: 1000,
+  persistIntervalMs: 2000,
+  persistJitterMs: 0,
+  circuitOpenIntervalMs: 5000,
+  maxRetryAttempts: 3,
+  retryDelaysMs: [100, 200, 400],
+};
+
+const makeCallbacks = (): PresenceHeartbeatCallbacks & {
+  failureCounts: number[];
+  successes: string[];
+  connectionErrors: number;
+  reconnects: number;
+} => {
+  const failureCounts: number[] = [];
+  const successes: string[] = [];
+  let connectionErrors = 0;
+  let reconnects = 0;
+
+  return {
+    failureCounts,
+    successes,
+    get connectionErrors() {
+      return connectionErrors;
+    },
+    get reconnects() {
+      return reconnects;
+    },
+    onFailureCountChange: (count) => failureCounts.push(count),
+    onSuccess: (timestamp) => successes.push(timestamp),
+    onConnectionError: () => {
+      connectionErrors += 1;
+    },
+    onReconnected: () => {
+      reconnects += 1;
+    },
+  };
+};
+
+describe('presence-heartbeat-controller', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defines the expected production config', () => {
+    expect(DEFAULT_PRESENCE_HEARTBEAT_CONFIG).toEqual({
+      trackIntervalMs: 10_000,
+      persistIntervalMs: 20_000,
+      persistJitterMs: 5_000,
+      circuitOpenIntervalMs: 30_000,
+      maxRetryAttempts: 5,
+      retryDelaysMs: [1000, 2000, 4000, 8000, 8000],
+    });
+  });
+
+  it('runs track and persist once immediately on start when persistEnabled', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const callbacks = makeCallbacks();
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      callbacks,
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: true });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run persist when persistEnabled is false', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: false });
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.trackIntervalMs * 3);
+
+    expect(persist).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledTimes(4); // t=0, 1000, 2000, 3000
+  });
+
+  it('reschedules track on trackIntervalMs after a success, independent of persist', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: true });
+    await vi.advanceTimersByTimeAsync(0); // t=0 tick
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.trackIntervalMs); // t=1000
+
+    expect(track).toHaveBeenCalledTimes(2);
+    expect(persist).toHaveBeenCalledTimes(1); // persistIntervalMs is 2000, not due yet
+  });
+
+  it('runs persist on its own persistIntervalMs cadence, slower than track', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: true });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.persistIntervalMs);
+
+    expect(track).toHaveBeenCalledTimes(3); // t=0, 1000, 2000
+    expect(persist).toHaveBeenCalledTimes(2); // t=0, 2000
+  });
+
+  it('applies jitter to the persist cadence, bounded by persistJitterMs', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const jitteredConfig: PresenceHeartbeatConfig = {
+      ...FAST_CONFIG,
+      persistJitterMs: 1000,
+    };
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      jitteredConfig
+    );
+
+    controller.start({ persistEnabled: true });
+    await vi.advanceTimersByTimeAsync(0); // t=0, first persist
+    // Math.random() = 0.5 -> jitter = 500ms -> next persist due at t=2500
+    await vi.advanceTimersByTimeAsync(2499);
+    expect(persist).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(persist).toHaveBeenCalledTimes(2);
+  });
+
+  it('backs off using retryDelaysMs on consecutive track failures', async () => {
+    const track = vi.fn().mockRejectedValue(new Error('track failed'));
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const callbacks = makeCallbacks();
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      callbacks,
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: false });
+    await vi.advanceTimersByTimeAsync(0); // attempt 1 fails
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(callbacks.failureCounts).toEqual([1]);
+
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[0]); // +100ms -> attempt 2
+    expect(track).toHaveBeenCalledTimes(2);
+    expect(callbacks.failureCounts).toEqual([1, 2]);
+
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[1]); // +200ms -> attempt 3
+    expect(track).toHaveBeenCalledTimes(3);
+    expect(callbacks.failureCounts).toEqual([1, 2, 3]);
+    expect(callbacks.connectionErrors).toBe(1); // tripped at maxRetryAttempts (3)
+  });
+
+  it('calls onConnectionError exactly once even if failures continue', async () => {
+    const track = vi.fn().mockRejectedValue(new Error('track failed'));
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const callbacks = makeCallbacks();
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      callbacks,
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: false });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[0]);
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[1]);
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.circuitOpenIntervalMs);
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.circuitOpenIntervalMs);
+
+    expect(callbacks.connectionErrors).toBe(1);
+  });
+
+  it('slows to circuitOpenIntervalMs once maxRetryAttempts is reached', async () => {
+    const track = vi.fn().mockRejectedValue(new Error('track failed'));
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: false });
+    await vi.advanceTimersByTimeAsync(0); // attempt 1
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[0]); // attempt 2
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[1]); // attempt 3 (circuit opens)
+    expect(track).toHaveBeenCalledTimes(3);
+
+    // Circuit open: next attempt should be circuitOpenIntervalMs away, not retryDelaysMs
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.circuitOpenIntervalMs - 1);
+    expect(track).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(track).toHaveBeenCalledTimes(4);
+  });
+
+  it('resets failureCount and calls onReconnected after recovery', async () => {
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const track = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail 1'))
+      .mockRejectedValueOnce(new Error('fail 2'))
+      .mockResolvedValue(undefined);
+    const callbacks = makeCallbacks();
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      callbacks,
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: false });
+    await vi.advanceTimersByTimeAsync(0); // fails (1)
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[0]); // fails (2)
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[1]); // succeeds
+
+    expect(controller.getFailureCount()).toBe(0);
+    expect(callbacks.reconnects).toBe(1);
+    expect(callbacks.connectionErrors).toBe(0); // recovered before hitting maxRetryAttempts
+  });
+
+  it('sendImmediate runs one track+persist attempt without starting scheduled loops', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      FAST_CONFIG
+    );
+
+    await controller.sendImmediate();
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.trackIntervalMs * 5);
+    expect(track).toHaveBeenCalledTimes(1); // no loop was started
+  });
+
+  it('stop() clears pending timers and prevents further ticks', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: true });
+    await vi.advanceTimersByTimeAsync(0);
+    controller.stop();
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.trackIntervalMs * 5);
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test presence-heartbeat-controller`
+Expected: FAIL — `Cannot find module '@lib/presence-heartbeat-controller'`
+
+- [ ] **Step 3: Implement `createPresenceHeartbeatController`**
+
+Create `src/lib/presence-heartbeat-controller.ts`:
+
+```typescript
+/**
+ * Presence heartbeat scheduling, retry/backoff, and circuit-breaker logic,
+ * extracted from usePresence so it can be unit-tested without rendering React
+ * (this repo has no jsdom/renderHook infra for hooks).
+ *
+ * Runs two independent loops:
+ * - track: cheap, websocket-based Realtime presence signal, on a fast cadence.
+ * - persist: DB-write heartbeat, on a slower, jittered cadence, since it is
+ *   the one that contributes to Postgres pool pressure under load.
+ *
+ * A shared failure counter and circuit breaker cover both loops: either one
+ * failing counts toward onConnectionError, and either one succeeding resets
+ * the counter and fires onReconnected if there had been prior failures.
+ */
+
+export type PresenceHeartbeatCallbacks = {
+  /** Called whenever the shared consecutive-failure count changes. */
+  onFailureCountChange: (count: number) => void;
+  /** Called on every successful track or persist attempt, with an ISO timestamp. */
+  onSuccess: (timestampIso: string) => void;
+  /** Called once, the moment failureCount first reaches maxRetryAttempts. */
+  onConnectionError: () => void;
+  /** Called once, the next time a heartbeat succeeds after prior failures. */
+  onReconnected: () => void;
+};
+
+export type PresenceHeartbeatConfig = {
+  /** Cadence for the Realtime presence track loop, in ms. */
+  trackIntervalMs: number;
+  /** Base cadence for the DB persist loop, in ms, before jitter. */
+  persistIntervalMs: number;
+  /** Max random jitter added to persistIntervalMs, in ms, fixed once per controller instance. */
+  persistJitterMs: number;
+  /** Flat cadence used once a stream's failure count reaches maxRetryAttempts. */
+  circuitOpenIntervalMs: number;
+  /** Number of consecutive failures on a stream before the circuit opens. */
+  maxRetryAttempts: number;
+  /** Backoff delays (ms) used for consecutive-failure attempts 1..maxRetryAttempts. */
+  retryDelaysMs: number[];
+};
+
+export const DEFAULT_PRESENCE_HEARTBEAT_CONFIG: PresenceHeartbeatConfig = {
+  trackIntervalMs: 10_000,
+  persistIntervalMs: 20_000,
+  persistJitterMs: 5_000,
+  circuitOpenIntervalMs: 30_000,
+  maxRetryAttempts: 5,
+  retryDelaysMs: [1000, 2000, 4000, 8000, 8000],
+};
+
+export interface PresenceHeartbeatController {
+  /** Start the track loop, and the persist loop if persistEnabled is true. */
+  start: (options: { persistEnabled: boolean }) => void;
+  /** Run one track + persist attempt immediately, outside the scheduled loops. */
+  sendImmediate: () => Promise<void>;
+  /** Stop all scheduled loops and clear pending timers. */
+  stop: () => void;
+  /** Current consecutive-failure count, shared across both loops. */
+  getFailureCount: () => number;
+}
+
+/**
+ * Create a presence heartbeat controller.
+ *
+ * @param track - Realtime presence track call (throws/rejects on failure)
+ * @param persist - DB heartbeat persist call (throws/rejects on failure)
+ * @param callbacks - Notified on failure-count changes, success, circuit trip, and recovery
+ * @param config - Cadence/backoff configuration (defaults to production values)
+ */
+export function createPresenceHeartbeatController(
+  track: () => Promise<void>,
+  persist: () => Promise<void>,
+  callbacks: PresenceHeartbeatCallbacks,
+  config: PresenceHeartbeatConfig = DEFAULT_PRESENCE_HEARTBEAT_CONFIG
+): PresenceHeartbeatController {
+  let failureCount = 0;
+  let hasCalledErrorCallback = false;
+  let trackTimeout: ReturnType<typeof setTimeout> | null = null;
+  let persistTimeout: ReturnType<typeof setTimeout> | null = null;
+  let stopped = true;
+  const persistJitter = Math.random() * config.persistJitterMs;
+
+  const nextDelayFor = (attempt: number): number =>
+    attempt < config.maxRetryAttempts
+      ? config.retryDelaysMs[
+          Math.min(attempt - 1, config.retryDelaysMs.length - 1)
+        ]
+      : config.circuitOpenIntervalMs;
+
+  const handleSuccess = (): void => {
+    const hadFailures = failureCount > 0;
+    failureCount = 0;
+    hasCalledErrorCallback = false;
+    callbacks.onFailureCountChange(0);
+    callbacks.onSuccess(new Date().toISOString());
+    if (hadFailures) {
+      callbacks.onReconnected();
+    }
+  };
+
+  const handleFailure = (error: unknown): number => {
+    failureCount += 1;
+    callbacks.onFailureCountChange(failureCount);
+
+    console.warn(
+      `[PresenceHeartbeatController] Heartbeat failed (attempt ${failureCount}):`,
+      error
+    );
+
+    if (failureCount >= config.maxRetryAttempts && !hasCalledErrorCallback) {
+      hasCalledErrorCallback = true;
+      callbacks.onConnectionError();
+    }
+
+    return failureCount;
+  };
+
+  const runTrackTick = async (): Promise<void> => {
+    let delay = config.trackIntervalMs;
+    try {
+      await track();
+      handleSuccess();
+    } catch (error) {
+      delay = nextDelayFor(handleFailure(error));
+    }
+    if (stopped) return;
+    trackTimeout = setTimeout(() => void runTrackTick(), delay);
+  };
+
+  const runPersistTick = async (): Promise<void> => {
+    let delay = config.persistIntervalMs + persistJitter;
+    try {
+      await persist();
+      handleSuccess();
+    } catch (error) {
+      delay = nextDelayFor(handleFailure(error));
+    }
+    if (stopped) return;
+    persistTimeout = setTimeout(() => void runPersistTick(), delay);
+  };
+
+  return {
+    start: ({ persistEnabled }) => {
+      stopped = false;
+      void runTrackTick();
+      if (persistEnabled) {
+        void runPersistTick();
+      }
+    },
+    sendImmediate: async () => {
+      try {
+        await track();
+        await persist();
+        handleSuccess();
+      } catch (error) {
+        handleFailure(error);
+      }
+    },
+    stop: () => {
+      stopped = true;
+      if (trackTimeout) clearTimeout(trackTimeout);
+      if (persistTimeout) clearTimeout(persistTimeout);
+      trackTimeout = null;
+      persistTimeout = null;
+    },
+    getFailureCount: () => failureCount,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn test presence-heartbeat-controller`
+Expected: PASS (12 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/presence-heartbeat-controller.ts src/tests/lib/presence-heartbeat-controller.test.ts
+git commit -m "feat: add presence heartbeat controller with decoupled track/persist cadence"
+```
+
+---
+
+### Task 2: Wire `usePresence` to the new controller
+
+**Files:**
+- Modify: `src/hooks/use-presence.tsx` (full rewrite of internals; public API unchanged)
+
+**Interfaces:**
+- Consumes: `createPresenceHeartbeatController` from Task 1 (`@lib/presence-heartbeat-controller`)
+- Produces: unchanged `UsePresenceOptions`/`UsePresenceReturn` (consumed by `src/hooks/use-reconnection.ts`, already correct, no changes needed there)
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace `src/hooks/use-presence.tsx` entirely with:
+
+```tsx
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import type {
+  IPresenceTracker,
+  PresenceState,
+} from '@infrastructure/realtime/presence-tracker';
+import { createPresenceHeartbeatController } from '@lib/presence-heartbeat-controller';
+
+const PresenceTrackerContext = createContext<IPresenceTracker | null>(null);
+
+export type PresenceTrackerProviderProps = {
+  tracker: IPresenceTracker;
+  children: ReactNode;
+};
+
+export const PresenceTrackerProvider = ({
+  tracker,
+  children,
+}: PresenceTrackerProviderProps) => (
+  <PresenceTrackerContext.Provider value={tracker}>
+    {children}
+  </PresenceTrackerContext.Provider>
+);
+
+export const usePresenceTracker = (): IPresenceTracker | null => {
+  return useContext(PresenceTrackerContext);
+};
+
+export type UsePresenceOptions = {
+  quizId: string;
+  playerId: string;
+  playerName: string;
+  /** Whether to persist presence to database (calls API endpoint) */
+  persistToDatabase?: boolean;
+  /** Called when presence sync occurs with all connected players */
+  onSync?: (presences: Record<string, PresenceState[]>) => void;
+  /** Called when a player joins */
+  onJoin?: (presences: PresenceState[]) => void;
+  /** Called when a player leaves */
+  onLeave?: (presences: PresenceState[]) => void;
+  /** Called after maxRetryAttempts consecutive heartbeat failures */
+  onConnectionError?: () => void;
+  /** Called when a heartbeat succeeds after previous failures */
+  onReconnected?: () => void;
+};
+
+export type UsePresenceReturn = {
+  /** Whether the presence connection is active */
+  isConnected: boolean;
+  /** Current presence state for all players */
+  presenceState: Record<string, PresenceState[]>;
+  /** Manually send an immediate track + persist attempt */
+  sendHeartbeat: () => Promise<void>;
+  /** Number of consecutive heartbeat failures */
+  failureCount: number;
+  /** Timestamp of last successful heartbeat */
+  lastSuccessfulHeartbeat: string | null;
+};
+
+/**
+ * Hook for tracking player presence in a quiz.
+ * Joins the presence channel on mount, runs the heartbeat controller's
+ * track/persist loops, and cleans up on unmount.
+ */
+export const usePresence = ({
+  quizId,
+  playerId,
+  playerName,
+  persistToDatabase = false,
+  onSync,
+  onJoin,
+  onLeave,
+  onConnectionError,
+  onReconnected,
+}: UsePresenceOptions): UsePresenceReturn => {
+  const tracker = usePresenceTracker();
+  const [isConnected, setIsConnected] = useState(false);
+  const [presenceState, setPresenceState] = useState<
+    Record<string, PresenceState[]>
+  >({});
+  const [failureCount, setFailureCount] = useState(0);
+  const [lastSuccessfulHeartbeat, setLastSuccessfulHeartbeat] = useState<
+    string | null
+  >(null);
+  const joinedAtRef = useRef<string>(new Date().toISOString());
+
+  // Latest-value refs so the controller's track/persist functions and
+  // callbacks never close over stale props, without needing to recreate
+  // the controller (and restart its timers) on every render.
+  const latestRef = useRef({ tracker, quizId, playerId, playerName, persistToDatabase });
+  latestRef.current = { tracker, quizId, playerId, playerName, persistToDatabase };
+  const onConnectionErrorRef = useRef(onConnectionError);
+  onConnectionErrorRef.current = onConnectionError;
+  const onReconnectedRef = useRef(onReconnected);
+  onReconnectedRef.current = onReconnected;
+
+  const track = useCallback(async () => {
+    const current = latestRef.current;
+    if (!current.tracker) return;
+    await current.tracker.track(current.quizId, {
+      playerId: current.playerId,
+      playerName: current.playerName,
+      joinedAt: joinedAtRef.current,
+    });
+  }, []);
+
+  const persist = useCallback(async () => {
+    const current = latestRef.current;
+    if (!current.persistToDatabase) return;
+
+    const response = await fetch(
+      `/api/quiz/${current.quizId}/player/${current.playerId}/presence`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ timestamp: new Date().toISOString() }),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Presence persist request failed with status ${response.status}`
+      );
+    }
+  }, []);
+
+  const controllerRef = useRef<ReturnType<
+    typeof createPresenceHeartbeatController
+  > | null>(null);
+  if (!controllerRef.current) {
+    controllerRef.current = createPresenceHeartbeatController(track, persist, {
+      onFailureCountChange: setFailureCount,
+      onSuccess: setLastSuccessfulHeartbeat,
+      onConnectionError: () => onConnectionErrorRef.current?.(),
+      onReconnected: () => onReconnectedRef.current?.(),
+    });
+  }
+
+  // Subscribe to presence and start the heartbeat controller on mount.
+  useEffect(() => {
+    if (!tracker) return;
+
+    const unsubscribe = tracker.subscribe(quizId, playerId, {
+      onSync: (state) => {
+        setPresenceState(state);
+        setIsConnected(true);
+        onSync?.(state);
+      },
+      onJoin: (presences) => {
+        setPresenceState(tracker.getPresenceState(quizId));
+        onJoin?.(presences);
+      },
+      onLeave: (presences) => {
+        setPresenceState(tracker.getPresenceState(quizId));
+        onLeave?.(presences);
+      },
+    });
+
+    controllerRef.current?.start({ persistEnabled: persistToDatabase });
+
+    return () => {
+      controllerRef.current?.stop();
+      void tracker.untrack(quizId);
+      unsubscribe();
+      setIsConnected(false);
+    };
+    // onSync/onJoin/onLeave intentionally included to match prior behavior;
+    // track/persist/controller are stable across renders (see refs above).
+  }, [tracker, quizId, playerId, persistToDatabase, onSync, onJoin, onLeave]);
+
+  return {
+    isConnected,
+    presenceState,
+    sendHeartbeat: () => controllerRef.current!.sendImmediate(),
+    failureCount,
+    lastSuccessfulHeartbeat,
+  };
+};
+```
+
+- [ ] **Step 2: Run the existing type-contract test to verify the public API is unchanged**
+
+Run: `yarn test use-presence`
+Expected: PASS (see Task 3 for cleanup of stale assertions in this file)
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `yarn test`
+Expected: PASS — no regressions in `use-reconnection.test.ts` or anywhere else importing `usePresence`'s types.
+
+- [ ] **Step 4: Run lint and typecheck**
+
+Run: `yarn lint`
+Expected: 0 errors (pre-existing warnings in unrelated files are fine, see baseline noted below)
+
+Run: `yarn build`
+Expected: succeeds (this also typechecks)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/use-presence.tsx
+git commit -m "fix: stop swallowing presence heartbeat DB-write failures
+
+Delegates track/persist scheduling and retry/backoff to the new
+PresenceHeartbeatController. persistPresence failures (including
+non-2xx responses, which previously weren't even detected) now
+propagate into the existing circuit-breaker instead of being
+silently caught, so useReconnection's disconnected/reconnecting
+state and ConnectionStatusBanner actually activate for DB failures."
+```
+
+---
+
+### Task 3: Clean up stale hook-level tests
+
+**Files:**
+- Modify: `src/tests/hooks/use-presence.test.ts`
+
+The existing file has a `Retry Configuration` describe block asserting hardcoded literals disconnected from any import (one literally asserts `heartbeatInterval = 30_000` labeled "30 seconds", which never matched the real 10s constant) — this is dead weight now that Task 1's `presence-heartbeat-controller.test.ts` provides real, behavior-verified coverage of retry delays, max attempts, and failure-count transitions. Remove the now-redundant/misleading blocks and keep only genuine type-contract checks.
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace `src/tests/hooks/use-presence.test.ts` entirely with:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import type {
+  UsePresenceOptions,
+  UsePresenceReturn,
+} from '@hooks/use-presence';
+
+/**
+ * Type-contract tests for usePresence's public API.
+ *
+ * Retry/backoff/circuit-breaker/cadence behavior is covered by
+ * src/tests/lib/presence-heartbeat-controller.test.ts, since this repo has
+ * no jsdom/renderHook infra to exercise the hook's timing logic directly.
+ */
+
+describe('usePresence', () => {
+  describe('Type Contracts', () => {
+    it('should define UsePresenceOptions with all required fields', () => {
+      const mockOptions: UsePresenceOptions = {
+        quizId: 'quiz-123',
+        playerId: 'player-456',
+        playerName: 'Test Player',
+        persistToDatabase: true,
+        onSync: () => {},
+        onJoin: () => {},
+        onLeave: () => {},
+        onConnectionError: () => {},
+        onReconnected: () => {},
+      };
+
+      expect(mockOptions).toHaveProperty('quizId');
+      expect(mockOptions).toHaveProperty('playerId');
+      expect(mockOptions).toHaveProperty('playerName');
+      expect(mockOptions).toHaveProperty('persistToDatabase');
+      expect(mockOptions).toHaveProperty('onSync');
+      expect(mockOptions).toHaveProperty('onJoin');
+      expect(mockOptions).toHaveProperty('onLeave');
+      expect(mockOptions).toHaveProperty('onConnectionError');
+      expect(mockOptions).toHaveProperty('onReconnected');
+    });
+
+    it('should define UsePresenceReturn with connection state', () => {
+      const mockReturn: UsePresenceReturn = {
+        isConnected: true,
+        presenceState: {},
+        sendHeartbeat: async () => {},
+        failureCount: 0,
+        lastSuccessfulHeartbeat: '2026-01-31T12:00:00Z',
+      };
+
+      expect(mockReturn).toHaveProperty('isConnected');
+      expect(mockReturn).toHaveProperty('presenceState');
+      expect(mockReturn).toHaveProperty('sendHeartbeat');
+      expect(mockReturn).toHaveProperty('failureCount');
+      expect(mockReturn).toHaveProperty('lastSuccessfulHeartbeat');
+
+      expect(typeof mockReturn.isConnected).toBe('boolean');
+      expect(typeof mockReturn.presenceState).toBe('object');
+      expect(typeof mockReturn.sendHeartbeat).toBe('function');
+      expect(typeof mockReturn.failureCount).toBe('number');
+      expect(
+        typeof mockReturn.lastSuccessfulHeartbeat === 'string' ||
+          mockReturn.lastSuccessfulHeartbeat === null
+      ).toBe(true);
+    });
+
+    it('should support optional callback props', () => {
+      const minimalOptions: UsePresenceOptions = {
+        quizId: 'quiz-123',
+        playerId: 'player-456',
+        playerName: 'Test Player',
+      };
+
+      expect(minimalOptions.persistToDatabase).toBeUndefined();
+      expect(minimalOptions.onSync).toBeUndefined();
+      expect(minimalOptions.onJoin).toBeUndefined();
+      expect(minimalOptions.onLeave).toBeUndefined();
+      expect(minimalOptions.onConnectionError).toBeUndefined();
+      expect(minimalOptions.onReconnected).toBeUndefined();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `yarn test use-presence`
+Expected: PASS (3 tests)
+
+- [ ] **Step 3: Run the full suite once more**
+
+Run: `yarn test`
+Expected: PASS, no regressions
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tests/hooks/use-presence.test.ts
+git commit -m "test: remove stale hardcoded retry-config assertions from use-presence.test.ts
+
+Superseded by real behavioral coverage in
+presence-heartbeat-controller.test.ts."
+```
+
+---
+
+### Task 4: Manual verification
+
+Not a code change — verifies the fix end-to-end the same way bug #1 was verified (Playwright MCP against the running dev server and the `Bobr Quiz Demo` quiz, join code `TRYBOBR`).
+
+- [ ] **Step 1: Join as a player and confirm normal heartbeat still works**
+
+Navigate to `/join`, enter join code `TRYBOBR`, pick a name, join. Confirm no errors in the browser console and the round progresses normally for ~30s (covers at least one persist-cadence tick).
+
+- [ ] **Step 2: Simulate a persistence failure**
+
+Temporarily edit `src/app/api/quiz/[quizId]/player/[playerId]/presence/route.ts` to force a failure (e.g., add `return NextResponse.json({ error: 'simulated' }, { status: 500 });` as the first line of the handler), save, and let the dev server hot-reload.
+
+- [ ] **Step 3: Confirm the player sees the reconnecting banner**
+
+Within ~30s (5 fast retries: 1+2+4+8+8s), the `ConnectionStatusBanner` should appear on the player screen showing "Connection lost. Trying to reconnect..." — confirm this via a Playwright snapshot.
+
+- [ ] **Step 4: Confirm recovery**
+
+Revert the temporary change from Step 2, save. Within the next persist attempt (circuit-open cadence, 30s), confirm the banner clears and shows "✓ Reconnected! Your session has been restored."
+
+- [ ] **Step 5: Confirm the host's view was sensible throughout**
+
+Check the host dashboard's Players panel during the simulated outage — the player should age through away/disconnected on the same schedule as before (that part is unchanged, and correct — the fix is that the *player* now knows, not that the host's view changes), then reflect the recovery once heartbeats resume.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** All four in-scope items from the design spec are covered — Task 1+2 fix error propagation (item 1) and add production logging (item 4, unconditional `console.warn` in the controller); Task 1's `persistIntervalMs`/`persistJitterMs` decouple and desynchronize the persist cadence (item 2); Task 1's `circuitOpenIntervalMs` slows cadence once the circuit is open (item 3).
+- **Placeholder scan:** No TBD/TODO; every step has complete, runnable code.
+- **Type consistency:** `PresenceHeartbeatController`'s shape (`start`/`sendImmediate`/`stop`/`getFailureCount`) is identical between Task 1's implementation and Task 2's consumption. `UsePresenceOptions`/`UsePresenceReturn` are byte-for-byte unchanged from the pre-existing public API, so `use-reconnection.ts` and `player-session-screen.tsx` need no changes (verified: neither imports anything beyond these two types).

--- a/docs/progress/plans/2026-07-05-presence-heartbeat-resilience-implementation.md
+++ b/docs/progress/plans/2026-07-05-presence-heartbeat-resilience-implementation.md
@@ -1,5 +1,7 @@
 # Presence Heartbeat Resilience Implementation Plan
 
+**Status:** ✅ Complete — merged via [PR #58](https://github.com/Banych/bobrquiz/pull/58)
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Stop the presence heartbeat from silently swallowing DB-write failures (which currently lets a fully-connected player be marked away/disconnected/removed with zero feedback), and reduce the heartbeat's contribution to Supabase pool connection pressure.
@@ -31,7 +33,7 @@
   - `DEFAULT_PRESENCE_HEARTBEAT_CONFIG: PresenceHeartbeatConfig` — the production values.
   - `PresenceHeartbeatController = { start: (options: { persistEnabled: boolean }) => void; sendImmediate: () => Promise<void>; stop: () => void; getFailureCount: () => number }`
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Create `src/tests/lib/presence-heartbeat-controller.test.ts`:
 
@@ -334,12 +336,12 @@ describe('presence-heartbeat-controller', () => {
 });
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `yarn test presence-heartbeat-controller`
 Expected: FAIL — `Cannot find module '@lib/presence-heartbeat-controller'`
 
-- [ ] **Step 3: Implement `createPresenceHeartbeatController`**
+- [x] **Step 3: Implement `createPresenceHeartbeatController`**
 
 Create `src/lib/presence-heartbeat-controller.ts`:
 
@@ -514,12 +516,12 @@ export function createPresenceHeartbeatController(
 }
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `yarn test presence-heartbeat-controller`
 Expected: PASS (12 tests)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/lib/presence-heartbeat-controller.ts src/tests/lib/presence-heartbeat-controller.test.ts
@@ -537,7 +539,7 @@ git commit -m "feat: add presence heartbeat controller with decoupled track/pers
 - Consumes: `createPresenceHeartbeatController` from Task 1 (`@lib/presence-heartbeat-controller`)
 - Produces: unchanged `UsePresenceOptions`/`UsePresenceReturn` (consumed by `src/hooks/use-reconnection.ts`, already correct, no changes needed there)
 
-- [ ] **Step 1: Replace the file contents**
+- [x] **Step 1: Replace the file contents**
 
 Replace `src/hooks/use-presence.tsx` entirely with:
 
@@ -731,17 +733,17 @@ export const usePresence = ({
 };
 ```
 
-- [ ] **Step 2: Run the existing type-contract test to verify the public API is unchanged**
+- [x] **Step 2: Run the existing type-contract test to verify the public API is unchanged**
 
 Run: `yarn test use-presence`
 Expected: PASS (see Task 3 for cleanup of stale assertions in this file)
 
-- [ ] **Step 3: Run the full test suite**
+- [x] **Step 3: Run the full test suite**
 
 Run: `yarn test`
 Expected: PASS — no regressions in `use-reconnection.test.ts` or anywhere else importing `usePresence`'s types.
 
-- [ ] **Step 4: Run lint and typecheck**
+- [x] **Step 4: Run lint and typecheck**
 
 Run: `yarn lint`
 Expected: 0 errors (pre-existing warnings in unrelated files are fine, see baseline noted below)
@@ -749,7 +751,7 @@ Expected: 0 errors (pre-existing warnings in unrelated files are fine, see basel
 Run: `yarn build`
 Expected: succeeds (this also typechecks)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/hooks/use-presence.tsx
@@ -772,7 +774,7 @@ state and ConnectionStatusBanner actually activate for DB failures."
 
 The existing file has a `Retry Configuration` describe block asserting hardcoded literals disconnected from any import (one literally asserts `heartbeatInterval = 30_000` labeled "30 seconds", which never matched the real 10s constant) — this is dead weight now that Task 1's `presence-heartbeat-controller.test.ts` provides real, behavior-verified coverage of retry delays, max attempts, and failure-count transitions. Remove the now-redundant/misleading blocks and keep only genuine type-contract checks.
 
-- [ ] **Step 1: Replace the file contents**
+- [x] **Step 1: Replace the file contents**
 
 Replace `src/tests/hooks/use-presence.test.ts` entirely with:
 
@@ -860,17 +862,17 @@ describe('usePresence', () => {
 });
 ```
 
-- [ ] **Step 2: Run tests to verify they pass**
+- [x] **Step 2: Run tests to verify they pass**
 
 Run: `yarn test use-presence`
 Expected: PASS (3 tests)
 
-- [ ] **Step 3: Run the full suite once more**
+- [x] **Step 3: Run the full suite once more**
 
 Run: `yarn test`
 Expected: PASS, no regressions
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src/tests/hooks/use-presence.test.ts
@@ -883,6 +885,8 @@ presence-heartbeat-controller.test.ts."
 ---
 
 ### Task 4: Manual verification
+
+**Skipped.** While attempting this, live Playwright testing found that `PresenceTrackerProvider` is never mounted anywhere in `src/app`, so `usePresenceTracker()` always returns `null` and the entire heartbeat (both `track()` and `persist()`) never starts at all in the running app — independent of this plan's fix, and pre-existing (confirmed identical in the pre-fix original file). There is currently no way to exercise the live retry/circuit-breaker/banner behavior against a running server, since the code path is unreachable. This is tracked as a separate follow-up (wire up the provider, then run this Task 4 procedure for real). Steps below are left as the procedure to run once that follow-up lands.
 
 Not a code change — verifies the fix end-to-end the same way bug #1 was verified (Playwright MCP against the running dev server and the `Bobr Quiz Demo` quiz, join code `TRYBOBR`).
 

--- a/src/hooks/use-presence.tsx
+++ b/src/hooks/use-presence.tsx
@@ -5,7 +5,6 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
@@ -14,16 +13,7 @@ import type {
   IPresenceTracker,
   PresenceState,
 } from '@infrastructure/realtime/presence-tracker';
-
-// Heartbeat interval for presence updates (10 seconds)
-// Must be well below CONNECTED_THRESHOLD_MS (30s) to avoid race conditions
-const PRESENCE_HEARTBEAT_INTERVAL_MS = 10_000;
-
-// Maximum number of consecutive failures before calling onConnectionError
-const MAX_RETRY_ATTEMPTS = 5;
-
-// Exponential backoff delays: 1s, 2s, 4s, 8s, 8s (capped at 8s)
-const RETRY_DELAYS_MS = [1000, 2000, 4000, 8000, 8000];
+import { createPresenceHeartbeatController } from '@lib/presence-heartbeat-controller';
 
 const PresenceTrackerContext = createContext<IPresenceTracker | null>(null);
 
@@ -57,9 +47,9 @@ export type UsePresenceOptions = {
   onJoin?: (presences: PresenceState[]) => void;
   /** Called when a player leaves */
   onLeave?: (presences: PresenceState[]) => void;
-  /** Called after 5 consecutive heartbeat failures */
+  /** Called after maxRetryAttempts consecutive heartbeat failures */
   onConnectionError?: () => void;
-  /** Called when heartbeat succeeds after previous failures */
+  /** Called when a heartbeat succeeds after previous failures */
   onReconnected?: () => void;
 };
 
@@ -68,7 +58,7 @@ export type UsePresenceReturn = {
   isConnected: boolean;
   /** Current presence state for all players */
   presenceState: Record<string, PresenceState[]>;
-  /** Manually send a presence heartbeat */
+  /** Manually send an immediate track + persist attempt */
   sendHeartbeat: () => Promise<void>;
   /** Number of consecutive heartbeat failures */
   failureCount: number;
@@ -78,8 +68,8 @@ export type UsePresenceReturn = {
 
 /**
  * Hook for tracking player presence in a quiz.
- * Joins the presence channel on mount, sends heartbeats on interval,
- * and cleans up on unmount.
+ * Joins the presence channel on mount, runs the heartbeat controller's
+ * track/persist loops, and cleans up on unmount.
  */
 export const usePresence = ({
   quizId,
@@ -101,109 +91,92 @@ export const usePresence = ({
   const [lastSuccessfulHeartbeat, setLastSuccessfulHeartbeat] = useState<
     string | null
   >(null);
-  const heartbeatIntervalRef = useRef<NodeJS.Timeout | null>(null);
-  const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const sendHeartbeatRef = useRef<() => Promise<void>>(async () => {});
   const joinedAtRef = useRef<string>(new Date().toISOString());
-  const hasCalledErrorCallbackRef = useRef(false);
 
-  // Persist presence to database via API
-  const persistPresence = useCallback(async () => {
-    if (!persistToDatabase) return;
-
-    try {
-      await fetch(`/api/quiz/${quizId}/player/${playerId}/presence`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ timestamp: new Date().toISOString() }),
-      });
-    } catch (error) {
-      if (process.env.NODE_ENV === 'development') {
-        console.warn('[usePresence] Failed to persist presence:', error);
-      }
-    }
-  }, [quizId, playerId, persistToDatabase]);
-
-  // Send presence heartbeat
-  const sendHeartbeat = useCallback(async () => {
-    if (!tracker) return;
-
-    const state: PresenceState = {
-      playerId,
-      playerName,
-      joinedAt: joinedAtRef.current,
-    };
-
-    try {
-      await tracker.track(quizId, state);
-      await persistPresence();
-
-      // Success: reset failure count and record timestamp
-      const hadFailures = failureCount > 0;
-      setFailureCount(0);
-      setLastSuccessfulHeartbeat(new Date().toISOString());
-      hasCalledErrorCallbackRef.current = false;
-
-      // Call reconnected callback if we recovered from failures
-      if (hadFailures && onReconnected) {
-        onReconnected();
-      }
-    } catch (error) {
-      // Failure: increment count and schedule retry
-      const newFailureCount = failureCount + 1;
-      setFailureCount(newFailureCount);
-
-      if (process.env.NODE_ENV === 'development') {
-        console.warn(
-          `[usePresence] Heartbeat failed (attempt ${newFailureCount}/${MAX_RETRY_ATTEMPTS}):`,
-          error
-        );
-      }
-
-      // After max retries, call error callback once
-      if (
-        newFailureCount >= MAX_RETRY_ATTEMPTS &&
-        onConnectionError &&
-        !hasCalledErrorCallbackRef.current
-      ) {
-        hasCalledErrorCallbackRef.current = true;
-        onConnectionError();
-      }
-
-      // Schedule retry with exponential backoff
-      if (newFailureCount < MAX_RETRY_ATTEMPTS) {
-        const delayIndex = Math.min(
-          newFailureCount - 1,
-          RETRY_DELAYS_MS.length - 1
-        );
-        const retryDelay = RETRY_DELAYS_MS[delayIndex];
-
-        retryTimeoutRef.current = setTimeout(() => {
-          void sendHeartbeatRef.current();
-        }, retryDelay);
-      }
-    }
-  }, [
+  // Latest-value refs so the controller's track/persist functions and
+  // callbacks never close over stale props, without needing to recreate
+  // the controller (and restart its timers) on every render. Synced in an
+  // effect rather than during render, since refs must not be written while
+  // rendering (react-hooks/refs).
+  const latestRef = useRef({
     tracker,
     quizId,
     playerId,
     playerName,
-    persistPresence,
-    failureCount,
-    onReconnected,
-    onConnectionError,
-  ]);
+    persistToDatabase,
+  });
+  const onConnectionErrorRef = useRef(onConnectionError);
+  const onReconnectedRef = useRef(onReconnected);
 
-  // Keep the ref up to date so the retry timeout always calls the latest version
-  useLayoutEffect(() => {
-    sendHeartbeatRef.current = sendHeartbeat;
+  useEffect(() => {
+    latestRef.current = {
+      tracker,
+      quizId,
+      playerId,
+      playerName,
+      persistToDatabase,
+    };
+    onConnectionErrorRef.current = onConnectionError;
+    onReconnectedRef.current = onReconnected;
   });
 
-  // Subscribe to presence and start heartbeat on mount
+  const track = useCallback(async () => {
+    const current = latestRef.current;
+    if (!current.tracker) return;
+    await current.tracker.track(current.quizId, {
+      playerId: current.playerId,
+      playerName: current.playerName,
+      joinedAt: joinedAtRef.current,
+    });
+  }, []);
+
+  const persist = useCallback(async () => {
+    const current = latestRef.current;
+    if (!current.persistToDatabase) return;
+
+    const response = await fetch(
+      `/api/quiz/${current.quizId}/player/${current.playerId}/presence`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ timestamp: new Date().toISOString() }),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Presence persist request failed with status ${response.status}`
+      );
+    }
+  }, []);
+
+  const controllerRef = useRef<ReturnType<
+    typeof createPresenceHeartbeatController
+  > | null>(null);
+
+  // Create the controller once on mount. Done in an effect (not directly in
+  // the render body) since refs must not be written while rendering; the
+  // ref-null check keeps this a one-time initialization even under
+  // StrictMode's double-invoke.
+  useEffect(() => {
+    if (controllerRef.current === null) {
+      controllerRef.current = createPresenceHeartbeatController(
+        track,
+        persist,
+        {
+          onFailureCountChange: setFailureCount,
+          onSuccess: setLastSuccessfulHeartbeat,
+          onConnectionError: () => onConnectionErrorRef.current?.(),
+          onReconnected: () => onReconnectedRef.current?.(),
+        }
+      );
+    }
+  }, [track, persist]);
+
+  // Subscribe to presence and start the heartbeat controller on mount.
   useEffect(() => {
     if (!tracker) return;
 
-    // Subscribe to presence events
     const unsubscribe = tracker.subscribe(quizId, playerId, {
       onSync: (state) => {
         setPresenceState(state);
@@ -220,34 +193,23 @@ export const usePresence = ({
       },
     });
 
-    // Track initial presence after subscription
-    void sendHeartbeat();
+    controllerRef.current?.start({ persistEnabled: persistToDatabase });
 
-    // Start heartbeat interval
-    heartbeatIntervalRef.current = setInterval(() => {
-      void sendHeartbeat();
-    }, PRESENCE_HEARTBEAT_INTERVAL_MS);
-
-    // Cleanup on unmount
     return () => {
-      if (heartbeatIntervalRef.current) {
-        clearInterval(heartbeatIntervalRef.current);
-        heartbeatIntervalRef.current = null;
-      }
-      if (retryTimeoutRef.current) {
-        clearTimeout(retryTimeoutRef.current);
-        retryTimeoutRef.current = null;
-      }
+      controllerRef.current?.stop();
       void tracker.untrack(quizId);
       unsubscribe();
       setIsConnected(false);
     };
-  }, [tracker, quizId, playerId, sendHeartbeat, onSync, onJoin, onLeave]);
+    // onSync/onJoin/onLeave intentionally included to match prior behavior;
+    // track/persist/controller are stable across renders (see refs above).
+  }, [tracker, quizId, playerId, persistToDatabase, onSync, onJoin, onLeave]);
 
   return {
     isConnected,
     presenceState,
-    sendHeartbeat,
+    sendHeartbeat: () =>
+      controllerRef.current?.sendImmediate() ?? Promise.resolve(),
     failureCount,
     lastSuccessfulHeartbeat,
   };

--- a/src/hooks/use-presence.tsx
+++ b/src/hooks/use-presence.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
@@ -95,9 +96,11 @@ export const usePresence = ({
 
   // Latest-value refs so the controller's track/persist functions and
   // callbacks never close over stale props, without needing to recreate
-  // the controller (and restart its timers) on every render. Synced in an
-  // effect rather than during render, since refs must not be written while
-  // rendering (react-hooks/refs).
+  // the controller (and restart its timers) on every render. Synced in a
+  // layout effect (not during render, since refs must not be written while
+  // rendering per react-hooks/refs) so the mirroring happens synchronously
+  // in the commit phase, before the controller's setTimeout-driven ticks
+  // can fire against a stale ref value.
   const latestRef = useRef({
     tracker,
     quizId,
@@ -108,7 +111,7 @@ export const usePresence = ({
   const onConnectionErrorRef = useRef(onConnectionError);
   const onReconnectedRef = useRef(onReconnected);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     latestRef.current = {
       tracker,
       quizId,
@@ -154,11 +157,13 @@ export const usePresence = ({
     typeof createPresenceHeartbeatController
   > | null>(null);
 
-  // Create the controller once on mount. Done in an effect (not directly in
-  // the render body) since refs must not be written while rendering; the
-  // ref-null check keeps this a one-time initialization even under
-  // StrictMode's double-invoke.
-  useEffect(() => {
+  // Create the controller once on mount. Done in a layout effect (not
+  // directly in the render body) since refs must not be written while
+  // rendering; using useLayoutEffect (rather than a passive effect) ensures
+  // the controller exists synchronously in the commit phase, before any
+  // other timing-sensitive effects below can run. The ref-null check keeps
+  // this a one-time initialization even under StrictMode's double-invoke.
+  useLayoutEffect(() => {
     if (controllerRef.current === null) {
       controllerRef.current = createPresenceHeartbeatController(
         track,

--- a/src/lib/presence-heartbeat-controller.ts
+++ b/src/lib/presence-heartbeat-controller.ts
@@ -1,0 +1,168 @@
+/**
+ * Presence heartbeat scheduling, retry/backoff, and circuit-breaker logic,
+ * extracted from usePresence so it can be unit-tested without rendering React
+ * (this repo has no jsdom/renderHook infra for hooks).
+ *
+ * Runs two independent loops:
+ * - track: cheap, websocket-based Realtime presence signal, on a fast cadence.
+ * - persist: DB-write heartbeat, on a slower, jittered cadence, since it is
+ *   the one that contributes to Postgres pool pressure under load.
+ *
+ * A shared failure counter and circuit breaker cover both loops: either one
+ * failing counts toward onConnectionError, and either one succeeding resets
+ * the counter and fires onReconnected if there had been prior failures.
+ */
+
+export type PresenceHeartbeatCallbacks = {
+  /** Called whenever the shared consecutive-failure count changes. */
+  onFailureCountChange: (count: number) => void;
+  /** Called on every successful track or persist attempt, with an ISO timestamp. */
+  onSuccess: (timestampIso: string) => void;
+  /** Called once, the moment failureCount first reaches maxRetryAttempts. */
+  onConnectionError: () => void;
+  /** Called once, the next time a heartbeat succeeds after prior failures. */
+  onReconnected: () => void;
+};
+
+export type PresenceHeartbeatConfig = {
+  /** Cadence for the Realtime presence track loop, in ms. */
+  trackIntervalMs: number;
+  /** Base cadence for the DB persist loop, in ms, before jitter. */
+  persistIntervalMs: number;
+  /** Max random jitter added to persistIntervalMs, in ms, fixed once per controller instance. */
+  persistJitterMs: number;
+  /** Flat cadence used once a stream's failure count reaches maxRetryAttempts. */
+  circuitOpenIntervalMs: number;
+  /** Number of consecutive failures on a stream before the circuit opens. */
+  maxRetryAttempts: number;
+  /** Backoff delays (ms) used for consecutive-failure attempts 1..maxRetryAttempts. */
+  retryDelaysMs: number[];
+};
+
+export const DEFAULT_PRESENCE_HEARTBEAT_CONFIG: PresenceHeartbeatConfig = {
+  trackIntervalMs: 10_000,
+  persistIntervalMs: 20_000,
+  persistJitterMs: 5_000,
+  circuitOpenIntervalMs: 30_000,
+  maxRetryAttempts: 5,
+  retryDelaysMs: [1000, 2000, 4000, 8000, 8000],
+};
+
+export interface PresenceHeartbeatController {
+  /** Start the track loop, and the persist loop if persistEnabled is true. */
+  start: (options: { persistEnabled: boolean }) => void;
+  /** Run one track + persist attempt immediately, outside the scheduled loops. */
+  sendImmediate: () => Promise<void>;
+  /** Stop all scheduled loops and clear pending timers. */
+  stop: () => void;
+  /** Current consecutive-failure count, shared across both loops. */
+  getFailureCount: () => number;
+}
+
+/**
+ * Create a presence heartbeat controller.
+ *
+ * @param track - Realtime presence track call (throws/rejects on failure)
+ * @param persist - DB heartbeat persist call (throws/rejects on failure)
+ * @param callbacks - Notified on failure-count changes, success, circuit trip, and recovery
+ * @param config - Cadence/backoff configuration (defaults to production values)
+ */
+export function createPresenceHeartbeatController(
+  track: () => Promise<void>,
+  persist: () => Promise<void>,
+  callbacks: PresenceHeartbeatCallbacks,
+  config: PresenceHeartbeatConfig = DEFAULT_PRESENCE_HEARTBEAT_CONFIG
+): PresenceHeartbeatController {
+  let failureCount = 0;
+  let hasCalledErrorCallback = false;
+  let trackTimeout: ReturnType<typeof setTimeout> | null = null;
+  let persistTimeout: ReturnType<typeof setTimeout> | null = null;
+  let stopped = true;
+  const persistJitter = Math.random() * config.persistJitterMs;
+
+  const nextDelayFor = (attempt: number): number =>
+    attempt < config.maxRetryAttempts
+      ? config.retryDelaysMs[
+          Math.min(attempt - 1, config.retryDelaysMs.length - 1)
+        ]
+      : config.circuitOpenIntervalMs;
+
+  const handleSuccess = (): void => {
+    const hadFailures = failureCount > 0;
+    failureCount = 0;
+    hasCalledErrorCallback = false;
+    callbacks.onFailureCountChange(0);
+    callbacks.onSuccess(new Date().toISOString());
+    if (hadFailures) {
+      callbacks.onReconnected();
+    }
+  };
+
+  const handleFailure = (error: unknown): number => {
+    failureCount += 1;
+    callbacks.onFailureCountChange(failureCount);
+
+    console.warn(
+      `[PresenceHeartbeatController] Heartbeat failed (attempt ${failureCount}):`,
+      error
+    );
+
+    if (failureCount >= config.maxRetryAttempts && !hasCalledErrorCallback) {
+      hasCalledErrorCallback = true;
+      callbacks.onConnectionError();
+    }
+
+    return failureCount;
+  };
+
+  const runTrackTick = async (): Promise<void> => {
+    let delay = config.trackIntervalMs;
+    try {
+      await track();
+      handleSuccess();
+    } catch (error) {
+      delay = nextDelayFor(handleFailure(error));
+    }
+    if (stopped) return;
+    trackTimeout = setTimeout(() => void runTrackTick(), delay);
+  };
+
+  const runPersistTick = async (): Promise<void> => {
+    let delay = config.persistIntervalMs + persistJitter;
+    try {
+      await persist();
+      handleSuccess();
+    } catch (error) {
+      delay = nextDelayFor(handleFailure(error));
+    }
+    if (stopped) return;
+    persistTimeout = setTimeout(() => void runPersistTick(), delay);
+  };
+
+  return {
+    start: ({ persistEnabled }) => {
+      stopped = false;
+      void runTrackTick();
+      if (persistEnabled) {
+        void runPersistTick();
+      }
+    },
+    sendImmediate: async () => {
+      try {
+        await track();
+        await persist();
+        handleSuccess();
+      } catch (error) {
+        handleFailure(error);
+      }
+    },
+    stop: () => {
+      stopped = true;
+      if (trackTimeout) clearTimeout(trackTimeout);
+      if (persistTimeout) clearTimeout(persistTimeout);
+      trackTimeout = null;
+      persistTimeout = null;
+    },
+    getFailureCount: () => failureCount,
+  };
+}

--- a/src/lib/presence-heartbeat-controller.ts
+++ b/src/lib/presence-heartbeat-controller.ts
@@ -8,19 +8,22 @@
  * - persist: DB-write heartbeat, on a slower, jittered cadence, since it is
  *   the one that contributes to Postgres pool pressure under load.
  *
- * A shared failure counter and circuit breaker cover both loops: either one
- * failing counts toward onConnectionError, and either one succeeding resets
- * the counter and fires onReconnected if there had been prior failures.
+ * Each loop maintains its own failure streak, since they can diverge (e.g. a
+ * DB outage fails persist while the separate Realtime websocket keeps
+ * succeeding) — a shared counter would let one loop's success mask the
+ * other's ongoing failures. The circuit trips (onConnectionError, once) the
+ * moment either stream's streak first reaches maxRetryAttempts, and clears
+ * (onReconnected) once both streams are healthy again.
  */
 
 export type PresenceHeartbeatCallbacks = {
-  /** Called whenever the shared consecutive-failure count changes. */
+  /** Called whenever the higher of the two loops' consecutive-failure counts changes. */
   onFailureCountChange: (count: number) => void;
   /** Called on every successful track or persist attempt, with an ISO timestamp. */
   onSuccess: (timestampIso: string) => void;
-  /** Called once, the moment failureCount first reaches maxRetryAttempts. */
+  /** Called once, the moment either stream's failure count first reaches maxRetryAttempts. */
   onConnectionError: () => void;
-  /** Called once, the next time a heartbeat succeeds after prior failures. */
+  /** Called once, when both streams have recovered after prior failures. */
   onReconnected: () => void;
 };
 
@@ -55,7 +58,7 @@ export interface PresenceHeartbeatController {
   sendImmediate: () => Promise<void>;
   /** Stop all scheduled loops and clear pending timers. */
   stop: () => void;
-  /** Current consecutive-failure count, shared across both loops. */
+  /** Higher of the two streams' current consecutive-failure counts. */
   getFailureCount: () => number;
 }
 
@@ -73,7 +76,9 @@ export function createPresenceHeartbeatController(
   callbacks: PresenceHeartbeatCallbacks,
   config: PresenceHeartbeatConfig = DEFAULT_PRESENCE_HEARTBEAT_CONFIG
 ): PresenceHeartbeatController {
-  let failureCount = 0;
+  let trackFailureCount = 0;
+  let persistFailureCount = 0;
+  let lastReportedFailureCount = 0;
   let hasCalledErrorCallback = false;
   let trackTimeout: ReturnType<typeof setTimeout> | null = null;
   let persistTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -87,41 +92,83 @@ export function createPresenceHeartbeatController(
         ]
       : config.circuitOpenIntervalMs;
 
-  const handleSuccess = (): void => {
-    const hadFailures = failureCount > 0;
-    failureCount = 0;
-    hasCalledErrorCallback = false;
-    callbacks.onFailureCountChange(0);
+  const isAnyStreamFailing = (): boolean =>
+    trackFailureCount > 0 || persistFailureCount > 0;
+
+  const isCircuitTripped = (): boolean =>
+    trackFailureCount >= config.maxRetryAttempts ||
+    persistFailureCount >= config.maxRetryAttempts;
+
+  const reportFailureCount = (): void => {
+    const nextCount = Math.max(trackFailureCount, persistFailureCount);
+    if (nextCount === lastReportedFailureCount) return;
+    lastReportedFailureCount = nextCount;
+    callbacks.onFailureCountChange(nextCount);
+  };
+
+  const handleTrackSuccess = (): void => {
+    const hadFailures = trackFailureCount > 0;
+    trackFailureCount = 0;
+    reportFailureCount();
     callbacks.onSuccess(new Date().toISOString());
-    if (hadFailures) {
+    if (hadFailures && !isAnyStreamFailing()) {
+      hasCalledErrorCallback = false;
       callbacks.onReconnected();
     }
   };
 
-  const handleFailure = (error: unknown): number => {
-    failureCount += 1;
-    callbacks.onFailureCountChange(failureCount);
+  const handlePersistSuccess = (): void => {
+    const hadFailures = persistFailureCount > 0;
+    persistFailureCount = 0;
+    reportFailureCount();
+    callbacks.onSuccess(new Date().toISOString());
+    if (hadFailures && !isAnyStreamFailing()) {
+      hasCalledErrorCallback = false;
+      callbacks.onReconnected();
+    }
+  };
+
+  const handleTrackFailure = (error: unknown): number => {
+    trackFailureCount += 1;
+    reportFailureCount();
 
     console.warn(
-      `[PresenceHeartbeatController] Heartbeat failed (attempt ${failureCount}):`,
+      `[PresenceHeartbeatController] Track heartbeat failed (attempt ${trackFailureCount}):`,
       error
     );
 
-    if (failureCount >= config.maxRetryAttempts && !hasCalledErrorCallback) {
+    if (isCircuitTripped() && !hasCalledErrorCallback) {
       hasCalledErrorCallback = true;
       callbacks.onConnectionError();
     }
 
-    return failureCount;
+    return trackFailureCount;
+  };
+
+  const handlePersistFailure = (error: unknown): number => {
+    persistFailureCount += 1;
+    reportFailureCount();
+
+    console.warn(
+      `[PresenceHeartbeatController] Persist heartbeat failed (attempt ${persistFailureCount}):`,
+      error
+    );
+
+    if (isCircuitTripped() && !hasCalledErrorCallback) {
+      hasCalledErrorCallback = true;
+      callbacks.onConnectionError();
+    }
+
+    return persistFailureCount;
   };
 
   const runTrackTick = async (): Promise<void> => {
     let delay = config.trackIntervalMs;
     try {
       await track();
-      handleSuccess();
+      handleTrackSuccess();
     } catch (error) {
-      delay = nextDelayFor(handleFailure(error));
+      delay = nextDelayFor(handleTrackFailure(error));
     }
     if (stopped) return;
     trackTimeout = setTimeout(() => void runTrackTick(), delay);
@@ -131,9 +178,9 @@ export function createPresenceHeartbeatController(
     let delay = config.persistIntervalMs + persistJitter;
     try {
       await persist();
-      handleSuccess();
+      handlePersistSuccess();
     } catch (error) {
-      delay = nextDelayFor(handleFailure(error));
+      delay = nextDelayFor(handlePersistFailure(error));
     }
     if (stopped) return;
     persistTimeout = setTimeout(() => void runPersistTick(), delay);
@@ -150,10 +197,15 @@ export function createPresenceHeartbeatController(
     sendImmediate: async () => {
       try {
         await track();
-        await persist();
-        handleSuccess();
+        handleTrackSuccess();
       } catch (error) {
-        handleFailure(error);
+        handleTrackFailure(error);
+      }
+      try {
+        await persist();
+        handlePersistSuccess();
+      } catch (error) {
+        handlePersistFailure(error);
       }
     },
     stop: () => {
@@ -163,6 +215,6 @@ export function createPresenceHeartbeatController(
       trackTimeout = null;
       persistTimeout = null;
     },
-    getFailureCount: () => failureCount,
+    getFailureCount: () => Math.max(trackFailureCount, persistFailureCount),
   };
 }

--- a/src/tests/hooks/use-presence.test.ts
+++ b/src/tests/hooks/use-presence.test.ts
@@ -5,10 +5,11 @@ import type {
 } from '@hooks/use-presence';
 
 /**
- * Tests for usePresence hook
+ * Type-contract tests for usePresence's public API.
  *
- * NOTE: These tests validate hook exports, type contracts, and configuration only.
- * Retry logic, exponential backoff, and event callbacks are tested via integration/E2E tests.
+ * Retry/backoff/circuit-breaker/cadence behavior is covered by
+ * src/tests/lib/presence-heartbeat-controller.test.ts, since this repo has
+ * no jsdom/renderHook infra to exercise the hook's timing logic directly.
  */
 
 describe('usePresence', () => {
@@ -69,153 +70,12 @@ describe('usePresence', () => {
         playerName: 'Test Player',
       };
 
-      // Optional fields should be undefined by default
       expect(minimalOptions.persistToDatabase).toBeUndefined();
       expect(minimalOptions.onSync).toBeUndefined();
       expect(minimalOptions.onJoin).toBeUndefined();
       expect(minimalOptions.onLeave).toBeUndefined();
       expect(minimalOptions.onConnectionError).toBeUndefined();
       expect(minimalOptions.onReconnected).toBeUndefined();
-    });
-  });
-
-  describe('Retry Configuration', () => {
-    it('should define exponential backoff delays', () => {
-      // Retry delays: 1s, 2s, 4s, 8s, 8s (capped at 8s)
-      const expectedDelays = [1000, 2000, 4000, 8000, 8000];
-
-      expect(expectedDelays).toHaveLength(5);
-      expect(expectedDelays[0]).toBe(1000); // 1st retry: 1s
-      expect(expectedDelays[1]).toBe(2000); // 2nd retry: 2s
-      expect(expectedDelays[2]).toBe(4000); // 3rd retry: 4s
-      expect(expectedDelays[3]).toBe(8000); // 4th retry: 8s
-      expect(expectedDelays[4]).toBe(8000); // 5th retry: 8s (capped)
-    });
-
-    it('should define max retry attempts', () => {
-      const maxRetries = 5;
-
-      expect(maxRetries).toBe(5);
-      expect(maxRetries).toBeGreaterThan(0);
-    });
-
-    it('should define heartbeat interval', () => {
-      const heartbeatInterval = 30_000; // 30 seconds
-
-      expect(heartbeatInterval).toBe(30000);
-      expect(heartbeatInterval).toBeGreaterThan(0);
-    });
-  });
-
-  describe('Return Value Structure', () => {
-    it('should return failureCount starting at 0', () => {
-      const mockReturn: UsePresenceReturn = {
-        isConnected: false,
-        presenceState: {},
-        sendHeartbeat: async () => {},
-        failureCount: 0,
-        lastSuccessfulHeartbeat: null,
-      };
-
-      expect(mockReturn.failureCount).toBe(0);
-      expect(mockReturn.lastSuccessfulHeartbeat).toBeNull();
-    });
-
-    it('should increment failureCount on consecutive failures', () => {
-      const failedStates = [
-        { failureCount: 0 },
-        { failureCount: 1 },
-        { failureCount: 2 },
-        { failureCount: 3 },
-        { failureCount: 4 },
-        { failureCount: 5 },
-      ];
-
-      failedStates.forEach((state, index) => {
-        expect(state.failureCount).toBe(index);
-      });
-    });
-
-    it('should reset failureCount after successful heartbeat', () => {
-      const beforeFailure = { failureCount: 0 };
-      const afterFailure = { failureCount: 3 };
-      const afterRecovery = { failureCount: 0 };
-
-      expect(beforeFailure.failureCount).toBe(0);
-      expect(afterFailure.failureCount).toBe(3);
-      expect(afterRecovery.failureCount).toBe(0);
-    });
-
-    it('should update lastSuccessfulHeartbeat timestamp on success', () => {
-      const mockReturn: UsePresenceReturn = {
-        isConnected: true,
-        presenceState: {},
-        sendHeartbeat: async () => {},
-        failureCount: 0,
-        lastSuccessfulHeartbeat: '2026-01-31T12:00:00.000Z',
-      };
-
-      expect(mockReturn.lastSuccessfulHeartbeat).toBeTruthy();
-      expect(typeof mockReturn.lastSuccessfulHeartbeat).toBe('string');
-
-      // Validate ISO 8601 format
-      const date = new Date(mockReturn.lastSuccessfulHeartbeat!);
-      expect(date.toISOString()).toBe('2026-01-31T12:00:00.000Z');
-    });
-  });
-
-  describe('Callback Signatures', () => {
-    it('should call onConnectionError after max retries', () => {
-      let errorCallbackCalled = false;
-      const mockOptions: UsePresenceOptions = {
-        quizId: 'quiz-123',
-        playerId: 'player-456',
-        playerName: 'Test Player',
-        onConnectionError: () => {
-          errorCallbackCalled = true;
-        },
-      };
-
-      // Simulate calling the callback
-      mockOptions.onConnectionError!();
-
-      expect(errorCallbackCalled).toBe(true);
-    });
-
-    it('should call onReconnected after successful retry', () => {
-      let reconnectedCallbackCalled = false;
-      const mockOptions: UsePresenceOptions = {
-        quizId: 'quiz-123',
-        playerId: 'player-456',
-        playerName: 'Test Player',
-        onReconnected: () => {
-          reconnectedCallbackCalled = true;
-        },
-      };
-
-      // Simulate calling the callback
-      mockOptions.onReconnected!();
-
-      expect(reconnectedCallbackCalled).toBe(true);
-    });
-
-    it('should not call onConnectionError multiple times', () => {
-      let callCount = 0;
-      const mockOptions: UsePresenceOptions = {
-        quizId: 'quiz-123',
-        playerId: 'player-456',
-        playerName: 'Test Player',
-        onConnectionError: () => {
-          callCount++;
-        },
-      };
-
-      // Simulate calling the callback once
-      mockOptions.onConnectionError!();
-      expect(callCount).toBe(1);
-
-      // Should only be called once even if failures continue
-      // (Implementation uses hasCalledErrorCallbackRef to prevent duplicates)
     });
   });
 });

--- a/src/tests/lib/presence-heartbeat-controller.test.ts
+++ b/src/tests/lib/presence-heartbeat-controller.test.ts
@@ -293,4 +293,35 @@ describe('presence-heartbeat-controller', () => {
     expect(track).toHaveBeenCalledTimes(1);
     expect(persist).toHaveBeenCalledTimes(1);
   });
+
+  it('does not mask persist failures with concurrent track successes (independent per-loop failure streaks)', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockRejectedValue(new Error('persist failed'));
+    const callbacks = makeCallbacks();
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      callbacks,
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: true });
+    await vi.advanceTimersByTimeAsync(0); // t=0: track succeeds, persist fails (1)
+    expect(callbacks.failureCounts).toEqual([1]);
+
+    await vi.advanceTimersByTimeAsync(100); // t=100: persist retry fails (2); track not due yet
+    expect(persist).toHaveBeenCalledTimes(2);
+    expect(callbacks.failureCounts).toEqual([1, 2]);
+
+    await vi.advanceTimersByTimeAsync(200); // t=300: persist retry fails (3) -> circuit trips
+    expect(persist).toHaveBeenCalledTimes(3);
+    expect(callbacks.connectionErrors).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(700); // t=1000: track tick fires and succeeds
+    expect(track).toHaveBeenCalledTimes(2);
+    // track succeeding must NOT clear persist's failure state or fire a spurious reconnect
+    expect(callbacks.connectionErrors).toBe(1);
+    expect(callbacks.reconnects).toBe(0);
+    expect(controller.getFailureCount()).toBe(3);
+  });
 });

--- a/src/tests/lib/presence-heartbeat-controller.test.ts
+++ b/src/tests/lib/presence-heartbeat-controller.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createPresenceHeartbeatController,
+  DEFAULT_PRESENCE_HEARTBEAT_CONFIG,
+  type PresenceHeartbeatCallbacks,
+  type PresenceHeartbeatConfig,
+} from '@lib/presence-heartbeat-controller';
+
+const FAST_CONFIG: PresenceHeartbeatConfig = {
+  trackIntervalMs: 1000,
+  persistIntervalMs: 2000,
+  persistJitterMs: 0,
+  circuitOpenIntervalMs: 5000,
+  maxRetryAttempts: 3,
+  retryDelaysMs: [100, 200, 400],
+};
+
+const makeCallbacks = (): PresenceHeartbeatCallbacks & {
+  failureCounts: number[];
+  successes: string[];
+  connectionErrors: number;
+  reconnects: number;
+} => {
+  const failureCounts: number[] = [];
+  const successes: string[] = [];
+  let connectionErrors = 0;
+  let reconnects = 0;
+
+  return {
+    failureCounts,
+    successes,
+    get connectionErrors() {
+      return connectionErrors;
+    },
+    get reconnects() {
+      return reconnects;
+    },
+    onFailureCountChange: (count) => failureCounts.push(count),
+    onSuccess: (timestamp) => successes.push(timestamp),
+    onConnectionError: () => {
+      connectionErrors += 1;
+    },
+    onReconnected: () => {
+      reconnects += 1;
+    },
+  };
+};
+
+describe('presence-heartbeat-controller', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defines the expected production config', () => {
+    expect(DEFAULT_PRESENCE_HEARTBEAT_CONFIG).toEqual({
+      trackIntervalMs: 10_000,
+      persistIntervalMs: 20_000,
+      persistJitterMs: 5_000,
+      circuitOpenIntervalMs: 30_000,
+      maxRetryAttempts: 5,
+      retryDelaysMs: [1000, 2000, 4000, 8000, 8000],
+    });
+  });
+
+  it('runs track and persist once immediately on start when persistEnabled', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const callbacks = makeCallbacks();
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      callbacks,
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: true });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run persist when persistEnabled is false', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: false });
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.trackIntervalMs * 3);
+
+    expect(persist).not.toHaveBeenCalled();
+    expect(track).toHaveBeenCalledTimes(4); // t=0, 1000, 2000, 3000
+  });
+
+  it('reschedules track on trackIntervalMs after a success, independent of persist', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: true });
+    await vi.advanceTimersByTimeAsync(0); // t=0 tick
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.trackIntervalMs); // t=1000
+
+    expect(track).toHaveBeenCalledTimes(2);
+    expect(persist).toHaveBeenCalledTimes(1); // persistIntervalMs is 2000, not due yet
+  });
+
+  it('runs persist on its own persistIntervalMs cadence, slower than track', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: true });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.persistIntervalMs);
+
+    expect(track).toHaveBeenCalledTimes(3); // t=0, 1000, 2000
+    expect(persist).toHaveBeenCalledTimes(2); // t=0, 2000
+  });
+
+  it('applies jitter to the persist cadence, bounded by persistJitterMs', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const jitteredConfig: PresenceHeartbeatConfig = {
+      ...FAST_CONFIG,
+      persistJitterMs: 1000,
+    };
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      jitteredConfig
+    );
+
+    controller.start({ persistEnabled: true });
+    await vi.advanceTimersByTimeAsync(0); // t=0, first persist
+    // Math.random() = 0.5 -> jitter = 500ms -> next persist due at t=2500
+    await vi.advanceTimersByTimeAsync(2499);
+    expect(persist).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(persist).toHaveBeenCalledTimes(2);
+  });
+
+  it('backs off using retryDelaysMs on consecutive track failures', async () => {
+    const track = vi.fn().mockRejectedValue(new Error('track failed'));
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const callbacks = makeCallbacks();
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      callbacks,
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: false });
+    await vi.advanceTimersByTimeAsync(0); // attempt 1 fails
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(callbacks.failureCounts).toEqual([1]);
+
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[0]); // +100ms -> attempt 2
+    expect(track).toHaveBeenCalledTimes(2);
+    expect(callbacks.failureCounts).toEqual([1, 2]);
+
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[1]); // +200ms -> attempt 3
+    expect(track).toHaveBeenCalledTimes(3);
+    expect(callbacks.failureCounts).toEqual([1, 2, 3]);
+    expect(callbacks.connectionErrors).toBe(1); // tripped at maxRetryAttempts (3)
+  });
+
+  it('calls onConnectionError exactly once even if failures continue', async () => {
+    const track = vi.fn().mockRejectedValue(new Error('track failed'));
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const callbacks = makeCallbacks();
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      callbacks,
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: false });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[0]);
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[1]);
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.circuitOpenIntervalMs);
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.circuitOpenIntervalMs);
+
+    expect(callbacks.connectionErrors).toBe(1);
+  });
+
+  it('slows to circuitOpenIntervalMs once maxRetryAttempts is reached', async () => {
+    const track = vi.fn().mockRejectedValue(new Error('track failed'));
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: false });
+    await vi.advanceTimersByTimeAsync(0); // attempt 1
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[0]); // attempt 2
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[1]); // attempt 3 (circuit opens)
+    expect(track).toHaveBeenCalledTimes(3);
+
+    // Circuit open: next attempt should be circuitOpenIntervalMs away, not retryDelaysMs
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.circuitOpenIntervalMs - 1);
+    expect(track).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(track).toHaveBeenCalledTimes(4);
+  });
+
+  it('resets failureCount and calls onReconnected after recovery', async () => {
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const track = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail 1'))
+      .mockRejectedValueOnce(new Error('fail 2'))
+      .mockResolvedValue(undefined);
+    const callbacks = makeCallbacks();
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      callbacks,
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: false });
+    await vi.advanceTimersByTimeAsync(0); // fails (1)
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[0]); // fails (2)
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.retryDelaysMs[1]); // succeeds
+
+    expect(controller.getFailureCount()).toBe(0);
+    expect(callbacks.reconnects).toBe(1);
+    expect(callbacks.connectionErrors).toBe(0); // recovered before hitting maxRetryAttempts
+  });
+
+  it('sendImmediate runs one track+persist attempt without starting scheduled loops', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      FAST_CONFIG
+    );
+
+    await controller.sendImmediate();
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.trackIntervalMs * 5);
+    expect(track).toHaveBeenCalledTimes(1); // no loop was started
+  });
+
+  it('stop() clears pending timers and prevents further ticks', async () => {
+    const track = vi.fn().mockResolvedValue(undefined);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    const controller = createPresenceHeartbeatController(
+      track,
+      persist,
+      makeCallbacks(),
+      FAST_CONFIG
+    );
+
+    controller.start({ persistEnabled: true });
+    await vi.advanceTimersByTimeAsync(0);
+    controller.stop();
+    await vi.advanceTimersByTimeAsync(FAST_CONFIG.trackIntervalMs * 5);
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes a production bug where a fully-connected player could be marked away/disconnected/removed with zero feedback, because the presence heartbeat's DB-write (`persistPresence`) silently swallowed all fetch failures and never checked `response.ok`, so the existing retry/backoff/circuit-breaker/reconnection-banner chain never activated for that failure class.
- Extracts the heartbeat's scheduling/retry/circuit-breaker logic into a new, framework-agnostic `src/lib/presence-heartbeat-controller.ts`, fully unit-tested with `vi.useFakeTimers()` (this repo has no jsdom/renderHook infra for hooks — this is why the original bug went uncaught by tests).
- Decouples the DB-persist cadence (~20-25s jittered) from the Realtime-track cadence (10s), reducing steady-state presence-related DB writes to ease Supabase connection-pool pressure.
- During final review, caught and fixed a second, more serious bug: the two decoupled loops initially shared one failure counter, so a healthy `track` loop (websocket) silently reset a failing `persist` loop's streak every cycle — meaning the circuit breaker could never trip for the exact DB-outage scenario this fix targets. Each loop now tracks its own failure streak.

## Related, explicitly out of scope

While attempting manual end-to-end verification, found that `PresenceTrackerProvider` is never mounted anywhere in `src/app`, so `usePresenceTracker()` always returns `null` and the entire heartbeat (track + persist) never runs at all in production today, independent of this fix. This pre-dates this branch and will be addressed as a separate follow-up plan.

## Test plan

- [x] `yarn test` — 452 passed, 1 skipped, no regressions
- [x] `yarn lint` — 0 errors
- [x] `yarn build` — succeeds
- [x] Per-task and final whole-branch reviews completed (subagent-driven-development), all Critical/Important findings resolved
- [ ] Manual Playwright verification deferred pending the `PresenceTrackerProvider` follow-up (the heartbeat path is currently unreachable in the running app)