### PR TITLE
fix: mount presence tracker provider and fix channel reuse crash

### DIFF
--- a/docs/progress/plans/2026-07-05-presence-channel-reuse-design.md
+++ b/docs/progress/plans/2026-07-05-presence-channel-reuse-design.md
@@ -1,0 +1,89 @@
+# Presence Channel Reuse Race — Design Spec
+
+**Status:** 📋 Approved, ready for implementation plan
+**Related:** `fix/presence-tracker-provider-mount` (Tasks 1-2, already committed on that branch) — mounting `PresenceTrackerProvider` made `SupabasePresenceTracker.subscribe()` actually execute for the first time in production, which immediately exposed this bug.
+
+## Background
+
+While running the manual verification for the `PresenceTrackerProvider` mounting fix, joining the demo quiz crashed the entire player screen 100% of the time:
+
+```
+Error: cannot add `presence` callbacks for realtime:presence:quiz:{quizId} after `subscribe()`.
+    at SupabasePresenceTracker.subscribe (src/infrastructure/realtime/presence-tracker.ts)
+```
+
+**Root cause:** `SupabasePresenceTracker.subscribe()` (`src/infrastructure/realtime/presence-tracker.ts`) caches one `RealtimeChannel` per `quizId` in its own `Map`, and on any call it unconditionally calls `channel.on(...)` to (re-)register presence event listeners before calling `channel.subscribe()`. Supabase's `realtime-js` throws if `.on()` is called on a channel that has already had `.subscribe()` called on it. When a component remounts quickly enough (observed via React 19 Strict Mode's dev-only double-invoke of effects — mount → unmount → remount within one commit), the remount's `subscribe()` call finds the channel this file's own `Map` still has cached (its cleanup is async and hadn't finished yet) and crashes trying to re-register listeners on it.
+
+**Why a naive reorder isn't sufficient:** the obvious fix — delete the entry from this file's own `Map` synchronously before doing the async `untrack()`/`unsubscribe()`, mirroring `src/infrastructure/realtime/broadcast-channel-pool.ts`'s `remove()` — does not fully solve this. Traced into the installed `@supabase/realtime-js` source (`node_modules/@supabase/realtime-js/dist/main/RealtimeClient.js`): `RealtimeClient.channel(topic)` **itself** deduplicates by topic name (`this.getChannels().find(c => c.topic === realtimeTopic)`), independent of this file's own cache. A channel is only removed from that internal registry via a "close" event listener that fires as part of the actual async unsubscribe/leave handshake with the server — not synchronously. So even with this file's own `Map` cleared immediately, calling `client.channel(sameTopic)` again right away would still hand back the *same*, already-subscribed channel object from Supabase's own registry, and the crash would still occur.
+
+**Test coverage gap:** `src/tests/infrastructure/realtime/presence-tracker.test.ts` exists but only tests a hand-written `MockPresenceTracker` fake — it never exercises `SupabasePresenceTracker` itself. This is the same class of gap that let the `usePresence` error-swallowing bug (fixed in PR #58) go undetected: a test file that looks like coverage but tests a parallel implementation instead of the real one.
+
+## Scope
+
+**In scope:**
+1. Change `SupabasePresenceTracker`'s channel reuse to survive quick remounts: keep the channel alive across a short grace period after `unsubscribe()` is called, canceling the pending teardown if a new `subscribe()` for the same `quizId` arrives in time — mirroring the already-working pattern in `broadcast-channel-pool.ts`.
+2. Route presence event callbacks (`onSync`/`onJoin`/`onLeave`) through a mutable handler object read at event-fire-time, so a reused channel never needs `.on()` called a second time, and always reflects the latest subscriber's callbacks.
+3. Add real unit tests for `SupabasePresenceTracker` (mocking the Supabase client/channel), covering the reuse-within-grace-period and teardown-after-grace-period behaviors — closing the test-coverage gap that let this bug ship.
+4. Manual re-verification: confirm joining the demo quiz no longer crashes, then complete the `PresenceTrackerProvider` plan's originally-deferred Task 3 verification (heartbeat POST requests appear, failure-simulation banner, recovery).
+
+**Out of scope (non-goals):**
+- No changes to `NoopPresenceTracker`, `getPresenceTracker()`'s caching, or Supabase client construction.
+- No changes to `usePresence`'s public interface or its synchronous `subscribe()`-returns-a-synchronous-unsubscribe-function usage pattern — the fix stays entirely inside `SupabasePresenceTracker`.
+- No attempt to fully close the residual race described below (grace-timer-fires-then-immediately-resubscribes-during-in-flight-teardown) — accepted as a documented, vanishingly-rare trade-off rather than making `subscribe()` async.
+- No changes to `broadcast-channel-pool.ts` itself (only used as a reference pattern).
+
+## Architecture
+
+`SupabasePresenceTracker`'s internal storage changes from `Map<string, RealtimeChannel>` to `Map<string, ChannelEntry>`:
+
+```ts
+type ChannelEntry = {
+  channel: RealtimeChannel;
+  handlers: PresenceSubscribeOptions;
+  teardownTimer: ReturnType<typeof setTimeout> | null;
+};
+
+const UNSUBSCRIBE_GRACE_PERIOD_MS = 3_000;
+```
+
+**`subscribe(quizId, playerId, options)`:**
+- If an entry already exists for `quizId` (channel alive, possibly with a teardown scheduled): cancel any pending `teardownTimer`, merge `options` into `entry.handlers` (`Object.assign`), return the unsubscribe closure. No `.on()`/`.subscribe()` call — the channel is already live and bound.
+- If no entry exists: create the channel via `this.client.channel(...)`, create a fresh `handlers` object from `options`, bind all three presence events **unconditionally** (`sync`/`join`/`leave` — each closure reads `handlers.onX?.(...)` at fire-time, not gated on whether the *first* caller happened to pass that particular callback), call `channel.subscribe(...)` once, store the new entry.
+- The returned closure looks up the *current* entry for `quizId` at call time (not a captured reference), so it always operates on whichever generation of subscribe/reuse is currently live, then schedules `entry.teardownTimer = setTimeout(() => { this.channels.delete(quizId); void this.teardownChannel(quizId, entry.channel); }, UNSUBSCRIBE_GRACE_PERIOD_MS)`.
+
+**`teardownChannel(quizId, channel)`** (new private method, replaces today's `unsubscribe(quizId)`): the actual async work — `await channel.untrack(); await channel.unsubscribe();` — run only after the map entry has already been deleted synchronously (matching `broadcast-channel-pool.ts`'s ordering), so it's fire-and-forget from the caller's perspective.
+
+**`track()`, `getPresenceState()`, `disconnect()`**: updated to read `entry.channel` instead of a bare `RealtimeChannel`. `disconnect()` additionally clears any pending `teardownTimer`s before tearing every channel down immediately (full shutdown shouldn't wait out grace periods).
+
+## Data flow
+
+No change to the public `IPresenceTracker` interface or to any caller (`usePresence`, `use-presence.tsx`). The fix is entirely internal to `SupabasePresenceTracker`; a fast remount (StrictMode double-invoke, or any real quick remount) now transparently reuses the same live channel instead of racing a teardown, so `usePresence`'s mount effect proceeds normally instead of crashing.
+
+## Testing
+
+`src/tests/infrastructure/realtime/presence-tracker.test.ts` gets a new `describe('SupabasePresenceTracker', ...)` block (the existing `MockPresenceTracker` tests stay — they test a different, legitimate fake used elsewhere, not a stand-in for this class) exercising the real class against a mocked Supabase client (`vi.fn()` for `channel`, `on`, `subscribe`, `untrack`, `unsubscribe`, `presenceState`) with `vi.useFakeTimers()`:
+- A second `subscribe()` call for the same `quizId` within the grace period does not call `.on()`/`.subscribe()` again, and reuses the same channel object.
+- A second `subscribe()` call after the grace period has elapsed (and the prior `unsubscribe()` closure fired) creates a fresh channel and rebinds listeners.
+- Updated `onSync`/`onJoin`/`onLeave` callbacks from a reuse-within-grace-period call are the ones actually invoked when a presence event fires afterward (proves the mutable-handlers indirection works).
+- `unsubscribe()`'s grace-period timer, once it elapses uncancelled, calls `channel.untrack()` then `channel.unsubscribe()`.
+
+## Error handling / residual risk
+
+A small window remains: if a new `subscribe()` for the same `quizId` lands in the (typically sub-100ms) gap between "grace timer fires and deletes the map entry" and "the async `untrack()`/`unsubscribe()` network round-trip actually completes," `client.channel()` would hand back the same not-yet-fully-released channel object from Supabase's own internal registry, and the original crash could recur — just far less likely than today (requires a coincidence after a 3s idle window, vs. today's ~0ms-guaranteed collision on every mount). Closing this fully would require making `subscribe()` async, which breaks its documented synchronous-return contract and `usePresence`'s effect-based usage — disproportionate to the residual likelihood. Documented as an accepted trade-off, not engineered around.
+
+A real tab-close/navigate-away during the grace window means the deferred client-side `untrack()`/`unsubscribe()` never runs — no worse than today (already async, just now delayed slightly longer), and this is exactly the gap the DB-persisted `lastSeenAt` heartbeat (fixed in PR #58) exists to backstop.
+
+## Risk / rollout
+
+Low-to-moderate risk — unlike the purely additive provider-mounting fix, this changes real subscription/timer logic, so it's backed by new, real unit tests plus a manual re-verification that joining no longer crashes and the deferred `PresenceTrackerProvider` Task 3 verification can finally complete. No feature flag needed: if the grace-period logic were subtly wrong, the worst case reproduces today's known crash rather than introducing a new failure mode.
+
+## Decision Log
+
+**Decision: grace-period channel reuse (Approach 1) over synchronous `teardown()` or never-cleanup**
+Traced Supabase's `realtime-js` source and confirmed `RealtimeClient.channel(topic)` dedupes by topic internally, with removal tied to an async close handshake — ruling out a simple synchronous-map-delete fix. Considered calling the channel's synchronous `teardown()` before recreating (Approach 2), but couldn't fully confirm from source that it synchronously detaches from Supabase's internal registry, and Approach 1 additionally fixes real-world fast remounts (not just the specific StrictMode trigger observed), so it was preferred. Considered never tearing down at all (Approach 3) — rejected since it leaves channels alive indefinitely with no real cleanup path, which the grace-period approach avoids at similar implementation cost.
+
+**Decision: accept the residual in-flight-teardown race rather than making `subscribe()` async**
+Would require changing `IPresenceTracker.subscribe()`'s synchronous contract and `usePresence`'s effect-based consumption of it. The residual window is a coincidence of timing after a 3-second idle period, several orders of magnitude less likely than today's guaranteed collision — not worth the interface churn.
+
+**Decision: add real `SupabasePresenceTracker` unit tests instead of only fixing the bug**
+The existing test file's `MockPresenceTracker`-only coverage is precisely why this bug (and the shared-failure-counter bug found in PR #58's final review) went undetected. Adding real tests against the actual class, mocking only the Supabase client boundary, closes this specific coverage gap going forward.

--- a/docs/progress/plans/2026-07-05-presence-channel-reuse-design.md
+++ b/docs/progress/plans/2026-07-05-presence-channel-reuse-design.md
@@ -1,6 +1,6 @@
 # Presence Channel Reuse Race — Design Spec
 
-**Status:** 📋 Approved, ready for implementation plan
+**Status:** ✅ Complete — merged via [PR #59](https://github.com/Banych/bobrquiz/pull/59)
 **Related:** `fix/presence-tracker-provider-mount` (Tasks 1-2, already committed on that branch) — mounting `PresenceTrackerProvider` made `SupabasePresenceTracker.subscribe()` actually execute for the first time in production, which immediately exposed this bug.
 
 ## Background

--- a/docs/progress/plans/2026-07-05-presence-channel-reuse-implementation.md
+++ b/docs/progress/plans/2026-07-05-presence-channel-reuse-implementation.md
@@ -1,0 +1,878 @@
+# Presence Channel Reuse Race Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `SupabasePresenceTracker.subscribe()` from crashing the player screen on remount (React Strict Mode's dev double-invoke, or any real fast remount), by keeping the channel alive for a short grace period after unsubscribe instead of racing its async teardown.
+
+**Architecture:** Change `SupabasePresenceTracker`'s internal `Map<string, RealtimeChannel>` to `Map<string, ChannelEntry>`, where each entry pairs the channel with a mutable, in-place-mutated `handlers` object that its `.on()` callbacks read at fire-time, and a pending-teardown timer. A `subscribe()` call for a `quizId` that already has a live entry cancels any scheduled teardown and reuses the channel (merging in the new handlers) instead of calling `.on()`/`.subscribe()` again — which Supabase's realtime-js forbids on an already-subscribed channel. `unsubscribe()` schedules teardown after a grace period instead of running it immediately, so a quick remount reuses the channel before it ever gets torn down.
+
+**Tech Stack:** TypeScript, `@supabase/supabase-js`, Vitest (`vi.useFakeTimers()`, `vi.advanceTimersByTimeAsync()`), no new dependencies.
+
+## Global Constraints
+
+- No changes to `NoopPresenceTracker`, `getPresenceTracker()`'s caching, or Supabase client construction.
+- No changes to `usePresence`'s public interface or its synchronous `subscribe()`-returns-a-synchronous-unsubscribe-function usage — the fix stays entirely inside `SupabasePresenceTracker`.
+- The `handlers` object on a `ChannelEntry` must be mutated in place (`Object.assign(entry.handlers, options)`), never reassigned to a new object — the channel's `.on()` closures capture that exact object reference, and reassigning would silently break reuse.
+- Grace period: `UNSUBSCRIBE_GRACE_PERIOD_MS = 3_000` (3 seconds).
+- Add real unit tests for `SupabasePresenceTracker` itself (mocking the Supabase client boundary) — the existing test file only covers a hand-written `MockPresenceTracker` fake, never the real class.
+
+---
+
+### Task 1: Grace-period channel reuse in `SupabasePresenceTracker`
+
+**Files:**
+- Modify: `src/infrastructure/realtime/presence-tracker.ts`
+- Modify: `src/tests/infrastructure/realtime/presence-tracker.test.ts`
+
+**Interfaces:**
+- Produces: `export class SupabasePresenceTracker implements IPresenceTracker` (currently unexported — exporting it is required so the test file can import and test it directly; its public methods — `subscribe`, `track`, `untrack`, `getPresenceState`, `disconnect` — keep their existing `IPresenceTracker` signatures unchanged).
+- No other file in the repo imports `SupabasePresenceTracker` by name today (only `getPresenceTracker()`'s return type, `IPresenceTracker`, is consumed elsewhere), so exporting it has no other call sites to update.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace `src/tests/infrastructure/realtime/presence-tracker.test.ts` entirely with (this preserves every existing `MockPresenceTracker` test unchanged and appends a new `describe` block):
+
+```typescript
+import {
+  type IPresenceTracker,
+  type PresenceState,
+  type PresenceSubscribeOptions,
+  SupabasePresenceTracker,
+} from '@infrastructure/realtime/presence-tracker';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Mock presence tracker for testing.
+ * Simulates Supabase Presence behavior without actual network calls.
+ */
+class MockPresenceTracker implements IPresenceTracker {
+  private presenceState: Map<string, Record<string, PresenceState[]>> =
+    new Map();
+  private subscriptions: Map<string, PresenceSubscribeOptions> = new Map();
+
+  subscribe(
+    quizId: string,
+    playerId: string,
+    options: PresenceSubscribeOptions
+  ): () => void {
+    this.subscriptions.set(quizId, options);
+    if (!this.presenceState.has(quizId)) {
+      this.presenceState.set(quizId, {});
+    }
+    return () => {
+      this.subscriptions.delete(quizId);
+    };
+  }
+
+  async track(quizId: string, state: PresenceState): Promise<void> {
+    const quizState = this.presenceState.get(quizId) ?? {};
+    quizState[state.playerId] = [state];
+    this.presenceState.set(quizId, quizState);
+
+    // Trigger callbacks
+    const options = this.subscriptions.get(quizId);
+    if (options?.onJoin) {
+      options.onJoin([state]);
+    }
+    if (options?.onSync) {
+      options.onSync(quizState);
+    }
+  }
+
+  async untrack(quizId: string): Promise<void> {
+    // In real implementation, this would remove the current player
+    // For mock, we just clear the state
+  }
+
+  getPresenceState(quizId: string): Record<string, PresenceState[]> {
+    return this.presenceState.get(quizId) ?? {};
+  }
+
+  disconnect(): void {
+    this.presenceState.clear();
+    this.subscriptions.clear();
+  }
+
+  // Test helpers
+  simulateJoin(quizId: string, state: PresenceState): void {
+    const quizState = this.presenceState.get(quizId) ?? {};
+    quizState[state.playerId] = [state];
+    this.presenceState.set(quizId, quizState);
+
+    const options = this.subscriptions.get(quizId);
+    if (options?.onJoin) {
+      options.onJoin([state]);
+    }
+  }
+
+  simulateLeave(quizId: string, state: PresenceState): void {
+    const quizState = this.presenceState.get(quizId) ?? {};
+    delete quizState[state.playerId];
+    this.presenceState.set(quizId, quizState);
+
+    const options = this.subscriptions.get(quizId);
+    if (options?.onLeave) {
+      options.onLeave([state]);
+    }
+  }
+
+  simulateSync(quizId: string): void {
+    const options = this.subscriptions.get(quizId);
+    if (options?.onSync) {
+      options.onSync(this.presenceState.get(quizId) ?? {});
+    }
+  }
+}
+
+describe('PresenceTracker', () => {
+  let tracker: MockPresenceTracker;
+
+  beforeEach(() => {
+    tracker = new MockPresenceTracker();
+  });
+
+  describe('subscribe', () => {
+    it('should return an unsubscribe function', () => {
+      const unsubscribe = tracker.subscribe('quiz-1', 'player-1', {});
+
+      expect(typeof unsubscribe).toBe('function');
+    });
+
+    it('should call onSync when sync event occurs', () => {
+      const onSync = vi.fn();
+      tracker.subscribe('quiz-1', 'player-1', { onSync });
+
+      tracker.simulateSync('quiz-1');
+
+      expect(onSync).toHaveBeenCalledWith({});
+    });
+
+    it('should call onJoin when player joins', () => {
+      const onJoin = vi.fn();
+      tracker.subscribe('quiz-1', 'player-1', { onJoin });
+
+      const state: PresenceState = {
+        playerId: 'player-2',
+        playerName: 'Alice',
+        joinedAt: new Date().toISOString(),
+      };
+      tracker.simulateJoin('quiz-1', state);
+
+      expect(onJoin).toHaveBeenCalledWith([state]);
+    });
+
+    it('should call onLeave when player leaves', () => {
+      const onLeave = vi.fn();
+      tracker.subscribe('quiz-1', 'player-1', { onLeave });
+
+      const state: PresenceState = {
+        playerId: 'player-2',
+        playerName: 'Alice',
+        joinedAt: new Date().toISOString(),
+      };
+      tracker.simulateLeave('quiz-1', state);
+
+      expect(onLeave).toHaveBeenCalledWith([state]);
+    });
+  });
+
+  describe('track', () => {
+    it('should add player to presence state', async () => {
+      tracker.subscribe('quiz-1', 'player-1', {});
+
+      const state: PresenceState = {
+        playerId: 'player-1',
+        playerName: 'Bob',
+        joinedAt: new Date().toISOString(),
+      };
+      await tracker.track('quiz-1', state);
+
+      const presenceState = tracker.getPresenceState('quiz-1');
+      expect(presenceState['player-1']).toEqual([state]);
+    });
+
+    it('should trigger onJoin callback', async () => {
+      const onJoin = vi.fn();
+      tracker.subscribe('quiz-1', 'player-1', { onJoin });
+
+      const state: PresenceState = {
+        playerId: 'player-1',
+        playerName: 'Bob',
+        joinedAt: new Date().toISOString(),
+      };
+      await tracker.track('quiz-1', state);
+
+      expect(onJoin).toHaveBeenCalledWith([state]);
+    });
+
+    it('should trigger onSync callback with updated state', async () => {
+      const onSync = vi.fn();
+      tracker.subscribe('quiz-1', 'player-1', { onSync });
+
+      const state: PresenceState = {
+        playerId: 'player-1',
+        playerName: 'Bob',
+        joinedAt: new Date().toISOString(),
+      };
+      await tracker.track('quiz-1', state);
+
+      expect(onSync).toHaveBeenCalledWith({ 'player-1': [state] });
+    });
+  });
+
+  describe('getPresenceState', () => {
+    it('should return empty object for unknown quiz', () => {
+      const state = tracker.getPresenceState('unknown-quiz');
+
+      expect(state).toEqual({});
+    });
+
+    it('should return current presence state', async () => {
+      tracker.subscribe('quiz-1', 'player-1', {});
+
+      const state1: PresenceState = {
+        playerId: 'player-1',
+        playerName: 'Alice',
+        joinedAt: new Date().toISOString(),
+      };
+      await tracker.track('quiz-1', state1);
+
+      const state2: PresenceState = {
+        playerId: 'player-2',
+        playerName: 'Bob',
+        joinedAt: new Date().toISOString(),
+      };
+      tracker.simulateJoin('quiz-1', state2);
+
+      const presenceState = tracker.getPresenceState('quiz-1');
+      expect(Object.keys(presenceState)).toHaveLength(2);
+      expect(presenceState['player-1']).toEqual([state1]);
+      expect(presenceState['player-2']).toEqual([state2]);
+    });
+  });
+
+  describe('disconnect', () => {
+    it('should clear all presence state', async () => {
+      tracker.subscribe('quiz-1', 'player-1', {});
+      await tracker.track('quiz-1', {
+        playerId: 'player-1',
+        playerName: 'Alice',
+        joinedAt: new Date().toISOString(),
+      });
+
+      tracker.disconnect();
+
+      expect(tracker.getPresenceState('quiz-1')).toEqual({});
+    });
+  });
+
+  describe('multiple quizzes', () => {
+    it('should track presence separately per quiz', async () => {
+      tracker.subscribe('quiz-1', 'player-1', {});
+      tracker.subscribe('quiz-2', 'player-2', {});
+
+      await tracker.track('quiz-1', {
+        playerId: 'player-1',
+        playerName: 'Alice',
+        joinedAt: new Date().toISOString(),
+      });
+
+      await tracker.track('quiz-2', {
+        playerId: 'player-2',
+        playerName: 'Bob',
+        joinedAt: new Date().toISOString(),
+      });
+
+      const quiz1State = tracker.getPresenceState('quiz-1');
+      const quiz2State = tracker.getPresenceState('quiz-2');
+
+      expect(Object.keys(quiz1State)).toEqual(['player-1']);
+      expect(Object.keys(quiz2State)).toEqual(['player-2']);
+    });
+  });
+});
+
+/**
+ * Mock Supabase channel/client for testing SupabasePresenceTracker's real
+ * channel reuse/teardown logic (not a stand-in fake -- this exercises the
+ * actual class, mocking only the Supabase client boundary).
+ */
+type MockChannel = {
+  on: ReturnType<typeof vi.fn>;
+  subscribe: ReturnType<typeof vi.fn>;
+  track: ReturnType<typeof vi.fn>;
+  untrack: ReturnType<typeof vi.fn>;
+  unsubscribe: ReturnType<typeof vi.fn>;
+  presenceState: ReturnType<typeof vi.fn>;
+  emit: (event: 'sync' | 'join' | 'leave', payload?: unknown) => void;
+};
+
+const createMockChannel = (): MockChannel => {
+  const listeners = new Map<string, (payload: unknown) => void>();
+
+  return {
+    on: vi.fn(
+      (
+        _type: string,
+        filter: { event: string },
+        callback: (payload: unknown) => void
+      ) => {
+        listeners.set(filter.event, callback);
+      }
+    ),
+    subscribe: vi.fn((callback?: (status: string) => void) => {
+      callback?.('SUBSCRIBED');
+    }),
+    track: vi.fn().mockResolvedValue('ok'),
+    untrack: vi.fn().mockResolvedValue('ok'),
+    unsubscribe: vi.fn().mockResolvedValue('ok'),
+    presenceState: vi.fn().mockReturnValue({}),
+    emit: (event, payload) => {
+      listeners.get(event)?.(payload);
+    },
+  };
+};
+
+const createMockClient = () => {
+  const channelsByName = new Map<string, MockChannel>();
+  const channel = vi.fn((name: string) => {
+    const mockChannel = createMockChannel();
+    channelsByName.set(name, mockChannel);
+    return mockChannel;
+  });
+  return {
+    client: { channel } as unknown as SupabaseClient,
+    channelsByName,
+    channelFn: channel,
+  };
+};
+
+describe('SupabasePresenceTracker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reuses the channel when subscribe is called again within the grace period', () => {
+    const { client, channelsByName, channelFn } = createMockClient();
+    const tracker = new SupabasePresenceTracker(client);
+
+    const unsubscribe1 = tracker.subscribe('quiz-1', 'player-1', {});
+    unsubscribe1();
+
+    tracker.subscribe('quiz-1', 'player-1', {});
+
+    expect(channelFn).toHaveBeenCalledTimes(1);
+    const channel = channelsByName.get('presence:quiz:quiz-1')!;
+    expect(channel.on).toHaveBeenCalledTimes(3);
+    expect(channel.subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a fresh channel when subscribe is called after the grace period elapses', async () => {
+    const { client, channelFn } = createMockClient();
+    const tracker = new SupabasePresenceTracker(client);
+
+    const unsubscribe1 = tracker.subscribe('quiz-1', 'player-1', {});
+    unsubscribe1();
+
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    tracker.subscribe('quiz-1', 'player-1', {});
+
+    expect(channelFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('routes presence events to the latest handlers after a reuse', () => {
+    const { client, channelsByName } = createMockClient();
+    const tracker = new SupabasePresenceTracker(client);
+
+    const onSync1 = vi.fn();
+    const unsubscribe1 = tracker.subscribe('quiz-1', 'player-1', {
+      onSync: onSync1,
+    });
+    unsubscribe1();
+
+    const onSync2 = vi.fn();
+    tracker.subscribe('quiz-1', 'player-1', { onSync: onSync2 });
+
+    const channel = channelsByName.get('presence:quiz:quiz-1')!;
+    channel.emit('sync');
+
+    expect(onSync1).not.toHaveBeenCalled();
+    expect(onSync2).toHaveBeenCalledTimes(1);
+  });
+
+  it('tears down the channel once the grace period elapses uncancelled', async () => {
+    const { client, channelsByName } = createMockClient();
+    const tracker = new SupabasePresenceTracker(client);
+
+    const unsubscribe = tracker.subscribe('quiz-1', 'player-1', {});
+    unsubscribe();
+
+    const channel = channelsByName.get('presence:quiz:quiz-1')!;
+    expect(channel.untrack).not.toHaveBeenCalled();
+    expect(channel.unsubscribe).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    expect(channel.untrack).toHaveBeenCalledTimes(1);
+    expect(channel.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call channel.untrack/unsubscribe if resubscribed before the grace period elapses', async () => {
+    const { client, channelsByName } = createMockClient();
+    const tracker = new SupabasePresenceTracker(client);
+
+    const unsubscribe1 = tracker.subscribe('quiz-1', 'player-1', {});
+    unsubscribe1();
+
+    tracker.subscribe('quiz-1', 'player-1', {});
+
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    const channel = channelsByName.get('presence:quiz:quiz-1')!;
+    expect(channel.untrack).not.toHaveBeenCalled();
+    expect(channel.unsubscribe).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test presence-tracker`
+Expected: FAIL — `SupabasePresenceTracker` is not yet exported from `@infrastructure/realtime/presence-tracker` (the class exists but has no `export` keyword yet), so the whole test file fails to load (either a "no matching export" module error, or `new SupabasePresenceTracker(...)` throwing "not a constructor" if the import resolves to `undefined`).
+
+- [ ] **Step 3: Implement the grace-period reuse logic**
+
+Replace `src/infrastructure/realtime/presence-tracker.ts` entirely with:
+
+```typescript
+import {
+  createClient,
+  type RealtimeChannel,
+  type SupabaseClient,
+} from '@supabase/supabase-js';
+
+/**
+ * Presence state tracked for each player.
+ */
+export type PresenceState = {
+  playerId: string;
+  playerName: string;
+  joinedAt: string;
+};
+
+/**
+ * Callback for presence events.
+ */
+export type PresenceEventHandler = (presences: PresenceState[]) => void;
+
+/**
+ * Callback for presence sync events with full state.
+ */
+export type PresenceSyncHandler = (
+  state: Record<string, PresenceState[]>
+) => void;
+
+/**
+ * Options for presence subscription.
+ */
+export type PresenceSubscribeOptions = {
+  onSync?: PresenceSyncHandler;
+  onJoin?: PresenceEventHandler;
+  onLeave?: PresenceEventHandler;
+};
+
+/**
+ * Interface for presence tracking operations.
+ */
+export interface IPresenceTracker {
+  /**
+   * Subscribe to presence events for a quiz.
+   * Returns an unsubscribe function.
+   */
+  subscribe(
+    quizId: string,
+    playerId: string,
+    options: PresenceSubscribeOptions
+  ): () => void;
+
+  /**
+   * Track player presence (call after subscribe).
+   */
+  track(quizId: string, state: PresenceState): Promise<void>;
+
+  /**
+   * Untrack player presence (call before unsubscribe or on disconnect).
+   */
+  untrack(quizId: string): Promise<void>;
+
+  /**
+   * Get current presence state for a quiz.
+   */
+  getPresenceState(quizId: string): Record<string, PresenceState[]>;
+
+  /**
+   * Disconnect all presence channels.
+   */
+  disconnect(): void;
+}
+
+const PRESENCE_CHANNEL_PREFIX = 'presence:quiz:';
+
+const getChannelName = (quizId: string): string =>
+  `${PRESENCE_CHANNEL_PREFIX}${quizId}`;
+
+/**
+ * How long to keep a channel alive after its last subscriber unsubscribes,
+ * before actually tearing it down. Survives quick remounts (React Strict
+ * Mode's dev-only double-invoke of effects, or any real fast remount)
+ * without re-calling `.on()` on an already-subscribed channel, which
+ * Supabase's realtime-js throws on.
+ */
+const UNSUBSCRIBE_GRACE_PERIOD_MS = 3_000;
+
+type ChannelEntry = {
+  channel: RealtimeChannel;
+  handlers: PresenceSubscribeOptions;
+  teardownTimer: ReturnType<typeof setTimeout> | null;
+};
+
+const logPresenceIssue = (
+  level: 'warn' | 'error',
+  message: string,
+  details: Record<string, unknown>
+) => {
+  if (level === 'error') {
+    console.error(`[PresenceTracker] ${message}`, details);
+  } else if (process.env.NODE_ENV === 'development') {
+    console.warn(`[PresenceTracker] ${message}`, details);
+  }
+};
+
+/**
+ * Supabase Presence Tracker implementation.
+ * Uses Supabase Realtime Presence API to track player connections.
+ *
+ * Channels are kept alive for UNSUBSCRIBE_GRACE_PERIOD_MS after their last
+ * subscriber unsubscribes, so a quick remount (React Strict Mode's
+ * dev-only double-invoke, or any real fast remount) reuses the same
+ * channel instead of racing its async teardown. Supabase's own realtime-js
+ * client dedupes channels by topic internally and only releases a topic
+ * asynchronously (via a close handshake), so recreating a channel for the
+ * same topic before that completes would hand back the same,
+ * already-subscribed object -- this is why reuse, not a faster teardown,
+ * is the fix.
+ */
+export class SupabasePresenceTracker implements IPresenceTracker {
+  private readonly client: SupabaseClient;
+  private readonly channels: Map<string, ChannelEntry> = new Map();
+
+  constructor(client: SupabaseClient) {
+    this.client = client;
+  }
+
+  subscribe(
+    quizId: string,
+    playerId: string,
+    options: PresenceSubscribeOptions
+  ): () => void {
+    let entry = this.channels.get(quizId);
+
+    if (entry) {
+      if (entry.teardownTimer !== null) {
+        clearTimeout(entry.teardownTimer);
+        entry.teardownTimer = null;
+      }
+      Object.assign(entry.handlers, options);
+    } else {
+      const channelName = getChannelName(quizId);
+      const channel = this.client.channel(channelName, {
+        config: {
+          presence: {
+            key: playerId,
+          },
+        },
+      });
+      const handlers: PresenceSubscribeOptions = { ...options };
+
+      channel.on('presence', { event: 'sync' }, () => {
+        const state = channel.presenceState<PresenceState>();
+        handlers.onSync?.(state);
+      });
+
+      channel.on(
+        'presence',
+        { event: 'join' },
+        ({ newPresences }: { newPresences: PresenceState[] }) => {
+          handlers.onJoin?.(newPresences);
+        }
+      );
+
+      channel.on(
+        'presence',
+        { event: 'leave' },
+        ({ leftPresences }: { leftPresences: PresenceState[] }) => {
+          handlers.onLeave?.(leftPresences);
+        }
+      );
+
+      channel.subscribe((status) => {
+        if (status !== 'SUBSCRIBED') {
+          logPresenceIssue('warn', 'Presence subscription status changed', {
+            quizId,
+            playerId,
+            status,
+          });
+        }
+      });
+
+      entry = { channel, handlers, teardownTimer: null };
+      this.channels.set(quizId, entry);
+    }
+
+    return () => {
+      const current = this.channels.get(quizId);
+      if (!current) return;
+
+      current.teardownTimer = setTimeout(() => {
+        this.channels.delete(quizId);
+        void this.teardownChannel(quizId, current.channel);
+      }, UNSUBSCRIBE_GRACE_PERIOD_MS);
+    };
+  }
+
+  async track(quizId: string, state: PresenceState): Promise<void> {
+    const entry = this.channels.get(quizId);
+    if (!entry) {
+      logPresenceIssue('warn', 'Cannot track: channel not found', { quizId });
+      return;
+    }
+
+    try {
+      await entry.channel.track(state);
+    } catch (error) {
+      logPresenceIssue('error', 'Failed to track presence', {
+        quizId,
+        state,
+        error,
+      });
+    }
+  }
+
+  async untrack(quizId: string): Promise<void> {
+    const entry = this.channels.get(quizId);
+    if (!entry) {
+      return;
+    }
+
+    try {
+      await entry.channel.untrack();
+    } catch (error) {
+      logPresenceIssue('warn', 'Failed to untrack presence', { quizId, error });
+    }
+  }
+
+  getPresenceState(quizId: string): Record<string, PresenceState[]> {
+    const entry = this.channels.get(quizId);
+    if (!entry) {
+      return {};
+    }
+    return entry.channel.presenceState<PresenceState>();
+  }
+
+  private async teardownChannel(
+    quizId: string,
+    channel: RealtimeChannel
+  ): Promise<void> {
+    try {
+      await channel.untrack();
+      await channel.unsubscribe();
+    } catch (error) {
+      logPresenceIssue('warn', 'Failed to unsubscribe from presence channel', {
+        quizId,
+        error,
+      });
+    }
+  }
+
+  disconnect(): void {
+    for (const [quizId, entry] of this.channels) {
+      if (entry.teardownTimer !== null) {
+        clearTimeout(entry.teardownTimer);
+      }
+      void this.teardownChannel(quizId, entry.channel);
+    }
+    this.channels.clear();
+  }
+}
+
+/**
+ * No-op presence tracker for when Supabase is not configured.
+ */
+class NoopPresenceTracker implements IPresenceTracker {
+  subscribe(): () => void {
+    return () => {};
+  }
+
+  async track(): Promise<void> {}
+
+  async untrack(): Promise<void> {}
+
+  getPresenceState(): Record<string, PresenceState[]> {
+    return {};
+  }
+
+  disconnect(): void {}
+}
+
+const getClientEnv = () => {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  return { url, anonKey } as const;
+};
+
+let cachedTracker: IPresenceTracker | null = null;
+
+/**
+ * Creates or returns a cached presence tracker instance.
+ * Uses Supabase Presence API when credentials are available,
+ * otherwise returns a no-op tracker.
+ */
+export const getPresenceTracker = (): IPresenceTracker => {
+  if (cachedTracker) {
+    return cachedTracker;
+  }
+
+  const { url, anonKey } = getClientEnv();
+
+  if (!url || !anonKey) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn(
+        '[PresenceTracker] Supabase env vars missing; using no-op tracker'
+      );
+    }
+    cachedTracker = new NoopPresenceTracker();
+    return cachedTracker;
+  }
+
+  const client = createClient(url, anonKey, {
+    auth: {
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+    realtime: {
+      params: {
+        eventsPerSecond: 10,
+      },
+    },
+  });
+
+  cachedTracker = new SupabasePresenceTracker(client);
+  return cachedTracker;
+};
+
+/**
+ * Resets the cached tracker (useful for testing).
+ */
+export const resetPresenceTracker = (): void => {
+  if (cachedTracker) {
+    cachedTracker.disconnect();
+    cachedTracker = null;
+  }
+};
+```
+
+Changes from the pre-existing file:
+- `SupabasePresenceTracker` is now `export`ed (was previously module-private).
+- Internal storage changed from `Map<string, RealtimeChannel>` to `Map<string, ChannelEntry>`.
+- `subscribe()` reuses an existing live entry (canceling any pending teardown, merging handlers in place) instead of unconditionally creating a channel and calling `.on()`/`.subscribe()`.
+- All three presence events (`sync`/`join`/`leave`) are now bound unconditionally at channel-creation time (was previously gated on `options.onSync`/`onJoin`/`onLeave` being truthy on the *first* caller) — necessary since a later reuse can supply a callback the first caller didn't.
+- The returned unsubscribe closure schedules a deferred `teardownTimer` instead of calling an immediate async `unsubscribe(quizId)` method.
+- New private `teardownChannel(quizId, channel)` replaces the old private `unsubscribe(quizId)` — same `untrack()`/`unsubscribe()` calls, now invoked only after the grace period (or immediately from `disconnect()`).
+- `disconnect()` now also clears any pending `teardownTimer`s before tearing every channel down immediately.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn test presence-tracker`
+Expected: PASS (17 tests: 12 existing `PresenceTracker`/`MockPresenceTracker` tests + 5 new `SupabasePresenceTracker` tests)
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `yarn test`
+Expected: PASS, no regressions.
+
+- [ ] **Step 6: Run lint and build**
+
+Run: `yarn lint`
+Expected: 0 errors
+
+Run: `yarn build`
+Expected: succeeds
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/infrastructure/realtime/presence-tracker.ts src/tests/infrastructure/realtime/presence-tracker.test.ts
+git commit -m "fix: keep presence channel alive across quick remounts
+
+SupabasePresenceTracker.subscribe() crashed on any remount fast enough
+that its async unsubscribe hadn't finished yet, because it
+unconditionally re-registered .on() listeners on a channel that had
+already had .subscribe() called on it, which Supabase's realtime-js
+forbids -- and because realtime-js itself dedupes channels by topic
+name, independent of this file's own cache, a simple synchronous-map-
+delete reorder wasn't sufficient on its own. Channels are now kept
+alive for a 3s grace period after unsubscribe, canceling the deferred
+teardown if a new subscribe for the same quiz arrives in time, with
+presence event handlers routed through a mutable object so a reused
+channel never needs .on() called twice."
+```
+
+---
+
+### Task 2: Manual verification
+
+Not a code change — confirms joining no longer crashes, then completes the `PresenceTrackerProvider` plan's originally-deferred verification (heartbeat POST requests appear, failure-simulation banner, recovery), which this bug had blocked.
+
+- [ ] **Step 1: Confirm joining no longer crashes**
+
+With the dev server running (picking up Task 1), navigate to `/join`, enter join code `TRYBOBR` (the `Bobr Quiz Demo` quiz), pick a name, join. Confirm via a Playwright snapshot that the actual player screen renders (not the generic "Something went wrong" error page), and confirm zero console errors.
+
+- [ ] **Step 2: Confirm the heartbeat fires**
+
+Using the Playwright MCP's network-requests tool, confirm at least one `POST /api/quiz/[quizId]/player/[playerId]/presence` request appears within the first ~25s.
+
+- [ ] **Step 3: Simulate a persistence failure**
+
+Temporarily edit `src/app/api/quiz/[quizId]/player/[playerId]/presence/route.ts` to force a failure — add as the first line inside the `POST` handler:
+
+```typescript
+return NextResponse.json({ error: 'simulated' }, { status: 500 });
+```
+
+Save and let the dev server hot-reload.
+
+- [ ] **Step 4: Confirm the player sees the reconnecting banner**
+
+Within ~30s (5 fast retries: 1+2+4+8+8s), the `ConnectionStatusBanner` should appear on the player screen showing "Connection lost. Trying to reconnect..." — confirm via a Playwright snapshot.
+
+- [ ] **Step 5: Confirm recovery**
+
+Revert the temporary change from Step 3, save. Within the next persist attempt (circuit-open cadence, 30s), confirm the banner clears and shows "✓ Reconnected! Your session has been restored."
+
+- [ ] **Step 6: Confirm the host's view was sensible throughout**
+
+Check the host dashboard's Players panel during the simulated outage — the player should age through away/disconnected on the same schedule as before, then reflect the recovery once heartbeats resume.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** All 4 in-scope items from the design spec are covered — Task 1 implements the grace-period reuse (items 1-2) and adds real `SupabasePresenceTracker` unit tests (item 3); Task 2 runs the manual verification, including the originally-deferred `PresenceTrackerProvider` Task 3 (item 4).
+- **Placeholder scan:** No TBD/TODO; every step has complete, runnable code.
+- **Type consistency:** `ChannelEntry`'s shape (`channel`/`handlers`/`teardownTimer`) is used identically across `subscribe()`, `track()`, `untrack()`, `getPresenceState()`, `disconnect()`, and `teardownChannel()`. The mock `MockChannel`/`createMockClient()` helpers in the test file expose exactly the methods (`on`, `subscribe`, `track`, `untrack`, `unsubscribe`, `presenceState`) that `SupabasePresenceTracker`'s implementation calls on a real `RealtimeChannel`.

--- a/docs/progress/plans/2026-07-05-presence-channel-reuse-implementation.md
+++ b/docs/progress/plans/2026-07-05-presence-channel-reuse-implementation.md
@@ -1,5 +1,7 @@
 # Presence Channel Reuse Race Implementation Plan
 
+**Status:** ✅ Complete — merged via [PR #59](https://github.com/Banych/bobrquiz/pull/59)
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Stop `SupabasePresenceTracker.subscribe()` from crashing the player screen on remount (React Strict Mode's dev double-invoke, or any real fast remount), by keeping the channel alive for a short grace period after unsubscribe instead of racing its async teardown.
@@ -28,7 +30,7 @@
 - Produces: `export class SupabasePresenceTracker implements IPresenceTracker` (currently unexported — exporting it is required so the test file can import and test it directly; its public methods — `subscribe`, `track`, `untrack`, `getPresenceState`, `disconnect` — keep their existing `IPresenceTracker` signatures unchanged).
 - No other file in the repo imports `SupabasePresenceTracker` by name today (only `getPresenceTracker()`'s return type, `IPresenceTracker`, is consumed elsewhere), so exporting it has no other call sites to update.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Replace `src/tests/infrastructure/realtime/presence-tracker.test.ts` entirely with (this preserves every existing `MockPresenceTracker` test unchanged and appends a new `describe` block):
 
@@ -441,12 +443,12 @@ describe('SupabasePresenceTracker', () => {
 });
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `yarn test presence-tracker`
 Expected: FAIL — `SupabasePresenceTracker` is not yet exported from `@infrastructure/realtime/presence-tracker` (the class exists but has no `export` keyword yet), so the whole test file fails to load (either a "no matching export" module error, or `new SupabasePresenceTracker(...)` throwing "not a constructor" if the import resolves to `undefined`).
 
-- [ ] **Step 3: Implement the grace-period reuse logic**
+- [x] **Step 3: Implement the grace-period reuse logic**
 
 Replace `src/infrastructure/realtime/presence-tracker.ts` entirely with:
 
@@ -796,17 +798,17 @@ Changes from the pre-existing file:
 - New private `teardownChannel(quizId, channel)` replaces the old private `unsubscribe(quizId)` — same `untrack()`/`unsubscribe()` calls, now invoked only after the grace period (or immediately from `disconnect()`).
 - `disconnect()` now also clears any pending `teardownTimer`s before tearing every channel down immediately.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `yarn test presence-tracker`
 Expected: PASS (17 tests: 12 existing `PresenceTracker`/`MockPresenceTracker` tests + 5 new `SupabasePresenceTracker` tests)
 
-- [ ] **Step 5: Run the full test suite**
+- [x] **Step 5: Run the full test suite**
 
 Run: `yarn test`
 Expected: PASS, no regressions.
 
-- [ ] **Step 6: Run lint and build**
+- [x] **Step 6: Run lint and build**
 
 Run: `yarn lint`
 Expected: 0 errors
@@ -814,7 +816,7 @@ Expected: 0 errors
 Run: `yarn build`
 Expected: succeeds
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add src/infrastructure/realtime/presence-tracker.ts src/tests/infrastructure/realtime/presence-tracker.test.ts
@@ -839,15 +841,15 @@ channel never needs .on() called twice."
 
 Not a code change — confirms joining no longer crashes, then completes the `PresenceTrackerProvider` plan's originally-deferred verification (heartbeat POST requests appear, failure-simulation banner, recovery), which this bug had blocked.
 
-- [ ] **Step 1: Confirm joining no longer crashes**
+- [x] **Step 1: Confirm joining no longer crashes**
 
 With the dev server running (picking up Task 1), navigate to `/join`, enter join code `TRYBOBR` (the `Bobr Quiz Demo` quiz), pick a name, join. Confirm via a Playwright snapshot that the actual player screen renders (not the generic "Something went wrong" error page), and confirm zero console errors.
 
-- [ ] **Step 2: Confirm the heartbeat fires**
+- [x] **Step 2: Confirm the heartbeat fires**
 
 Using the Playwright MCP's network-requests tool, confirm at least one `POST /api/quiz/[quizId]/player/[playerId]/presence` request appears within the first ~25s.
 
-- [ ] **Step 3: Simulate a persistence failure**
+- [x] **Step 3: Simulate a persistence failure**
 
 Temporarily edit `src/app/api/quiz/[quizId]/player/[playerId]/presence/route.ts` to force a failure — add as the first line inside the `POST` handler:
 
@@ -857,15 +859,15 @@ return NextResponse.json({ error: 'simulated' }, { status: 500 });
 
 Save and let the dev server hot-reload.
 
-- [ ] **Step 4: Confirm the player sees the reconnecting banner**
+- [x] **Step 4: Confirm the player sees the reconnecting banner**
 
 Within ~30s (5 fast retries: 1+2+4+8+8s), the `ConnectionStatusBanner` should appear on the player screen showing "Connection lost. Trying to reconnect..." — confirm via a Playwright snapshot.
 
-- [ ] **Step 5: Confirm recovery**
+- [x] **Step 5: Confirm recovery**
 
 Revert the temporary change from Step 3, save. Within the next persist attempt (circuit-open cadence, 30s), confirm the banner clears and shows "✓ Reconnected! Your session has been restored."
 
-- [ ] **Step 6: Confirm the host's view was sensible throughout**
+- [x] **Step 6: Confirm the host's view was sensible throughout**
 
 Check the host dashboard's Players panel during the simulated outage — the player should age through away/disconnected on the same schedule as before, then reflect the recovery once heartbeats resume.
 

--- a/docs/progress/plans/2026-07-05-presence-tracker-provider-design.md
+++ b/docs/progress/plans/2026-07-05-presence-tracker-provider-design.md
@@ -1,6 +1,6 @@
 # Presence Tracker Provider Mounting — Design Spec
 
-**Status:** 📋 Approved, ready for implementation plan
+**Status:** ✅ Complete — merged via [PR #59](https://github.com/Banych/bobrquiz/pull/59)
 **Related:** `fix/presence-heartbeat-resilience` (PR #58, merged) — that fix corrected the heartbeat's retry/backoff/circuit-breaker logic, but discovered during manual verification that the heartbeat never runs at all in production, independent of that fix.
 
 ## Background

--- a/docs/progress/plans/2026-07-05-presence-tracker-provider-design.md
+++ b/docs/progress/plans/2026-07-05-presence-tracker-provider-design.md
@@ -1,0 +1,132 @@
+# Presence Tracker Provider Mounting — Design Spec
+
+**Status:** 📋 Approved, ready for implementation plan
+**Related:** `fix/presence-heartbeat-resilience` (PR #58, merged) — that fix corrected the heartbeat's retry/backoff/circuit-breaker logic, but discovered during manual verification that the heartbeat never runs at all in production, independent of that fix.
+
+## Background
+
+During PR #58's manual (Playwright) verification, joining the demo quiz as a live player produced **zero requests** to `/api/quiz/[quizId]/player/[playerId]/presence` — not even during normal operation, before any failure was simulated. Tracing why:
+
+- `usePresence` (`src/hooks/use-presence.tsx`) gets its `IPresenceTracker` via `usePresenceTracker()`, a React context hook fed by `<PresenceTrackerProvider tracker={...}>`.
+- **`PresenceTrackerProvider` is never rendered anywhere in `src/app`.** `usePresenceTracker()` therefore always returns `null`.
+- The hook's mount effect does `if (!tracker) return;` **before** starting the heartbeat controller (the thing PR #58 fixed) — so in production today, neither `track()` (Realtime presence) nor `persist()` (the DB write) ever runs, for any player, ever.
+
+This is confirmed to be a genuine oversight, not a deliberate deferral: `PresenceTrackerProvider` and its backing factory `getPresenceTracker()` (`src/infrastructure/realtime/presence-tracker.ts`) were built in Phase 4.1 (commit `e81f631`, Jan 2026) alongside the rest of the presence-tracking foundation. The *other* realtime mechanism in this codebase (broadcast channels for `state:update`/`leaderboard:update`) has its own `RealtimeClientProvider`, correctly mounted app-wide in `src/app/providers.tsx` → `AppProviders` (used by `RootLayout`). `PresenceTrackerProvider` was simply never added alongside it — no session or plan doc ever lists "mount the provider" as a step, and nothing in the codebase or docs indicates it was intentionally left out.
+
+This single missing mount is sufficient, by itself, to fully explain the originally-reported production symptom (players marked away/disconnected quickly despite an open tab): with no heartbeat ever sent, `Player.lastSeenAt` is set once at join and then only ages via wall-clock time, with no refresh, regardless of tab state.
+
+## Scope
+
+**In scope:**
+1. Mount `PresenceTrackerProvider` app-wide in `AppProviders`, using the existing `getPresenceTracker()` factory — mirroring exactly how `RealtimeClientProvider` is already mounted there.
+2. Harden `usePresenceTracker()` to throw when the provider is missing, matching the sibling `useRealtimeClient()`'s existing fail-loud behavior, so this exact class of bug (a hook silently no-op'ing because its provider was never mounted) can't recur undetected. Extract the throw into a small, pure `assertPresenceTracker` helper so it's unit-testable without rendering (this repo has no jsdom/renderHook infra).
+3. Remove the two now-dead `if (!tracker) return` guards in `use-presence.tsx` (lines 128 and 183) that become unreachable once `usePresenceTracker()` can no longer return `null`, and tighten the corresponding type from `IPresenceTracker | null` to `IPresenceTracker`.
+4. Run PR #58's deferred Task 4 manual verification for real now that the heartbeat path is reachable, plus a preliminary check that `/presence` requests actually appear at all (the thing that was silently broken).
+
+**Out of scope (non-goals):**
+- No changes to `getPresenceTracker()`'s caching, `NoopPresenceTracker` fallback, or Supabase client construction — already correct.
+- No changes to the heartbeat controller, retry/backoff/circuit-breaker logic, or cadence — already fixed and verified in PR #58.
+- No changes to `useReconnection`, `ConnectionStatusBanner`, or `connection-status.ts`.
+- No scoping the provider to only the player route group instead of globally — mounting it in `AppProviders` matches the existing `RealtimeClientProvider` pattern exactly and keeps both realtime mechanisms wired consistently, even though (like `RealtimeClientProvider`) only some routes actually consume it.
+
+## Architecture
+
+Two small, mechanical changes, both following existing patterns exactly:
+
+```
+src/app/providers.tsx        — mount PresenceTrackerProvider alongside RealtimeClientProvider
+src/hooks/use-presence.tsx   — usePresenceTracker() fails loud; remove now-dead null guards
+src/tests/hooks/...          — unit test for the extracted assertPresenceTracker helper
+```
+
+### 1. Mount the provider
+
+`AppProviders` (`src/app/providers.tsx`) already does, for the other realtime client:
+
+```tsx
+const realtimeClient = useMemo(() => {
+  return createSupabaseRealtimeClient() ?? createNoopRealtimeClient();
+}, []);
+
+return (
+  <RealtimeClientProvider client={realtimeClient}>
+    ...
+```
+
+The fix adds the same pattern for presence, using the existing `getPresenceTracker()` factory (which already handles the Supabase-env-vars-missing case internally via its own `NoopPresenceTracker` fallback, so no `??` is needed here — unlike the realtime client, there's exactly one factory call):
+
+```tsx
+const presenceTracker = useState(getPresenceTracker)[0];
+
+return (
+  <PresenceTrackerProvider tracker={presenceTracker}>
+    <RealtimeClientProvider client={realtimeClient}>
+      ...
+```
+
+Since `getPresenceTracker()` itself caches a module-level singleton, `useState(getPresenceTracker)` (lazy initializer form) guarantees the factory runs once per component instance without needing a `useMemo` dependency array — consistent with how `AppProviders` already does `useState(createQueryClient)` for the query client just above it.
+
+### 2. Fail loud, not silent
+
+`usePresenceTracker()` currently:
+
+```ts
+export const usePresenceTracker = (): IPresenceTracker | null => {
+  return useContext(PresenceTrackerContext);
+};
+```
+
+Becomes:
+
+```ts
+export const assertPresenceTracker = (
+  tracker: IPresenceTracker | null
+): IPresenceTracker => {
+  if (!tracker) {
+    throw new Error(
+      'PresenceTrackerProvider is missing from the component tree.'
+    );
+  }
+  return tracker;
+};
+
+export const usePresenceTracker = (): IPresenceTracker => {
+  return assertPresenceTracker(useContext(PresenceTrackerContext));
+};
+```
+
+This mirrors `useRealtimeClient()`'s existing pattern (`src/hooks/use-realtime-client.tsx:22-32`) almost exactly, and — same as PR #58's `presence-heartbeat-controller.ts` extraction — pulls the actual logic-with-a-decision (the throw) into a plain function that can be unit tested directly, without rendering a component.
+
+### 3. Remove dead guards
+
+With `usePresenceTracker()` no longer nullable, `usePresence`'s `tracker` is always a real `IPresenceTracker`. The two guards that existed only to handle a `null` tracker become unreachable:
+
+- `src/hooks/use-presence.tsx:128` — `if (!current.tracker) return;` inside `track()`.
+- `src/hooks/use-presence.tsx:183` — `if (!tracker) return;` inside the mount effect.
+
+Both are removed; `latestRef`'s inferred type for `tracker` tightens from `IPresenceTracker | null` to `IPresenceTracker` automatically.
+
+## Error handling
+
+Fail loud at the DI boundary rather than fail silent. If a future refactor ever removes `PresenceTrackerProvider` from `AppProviders` again, any component calling `usePresence` will throw immediately in development/testing, surfacing the regression right away — instead of manifesting as a subtle, hard-to-diagnose production symptom (players aging through connection states for no visible reason), which is exactly what happened here.
+
+This is safe in every environment: `getPresenceTracker()`'s existing fallback to `NoopPresenceTracker` (when `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY` are missing — local dev without `.env`, CI, etc.) means the provider always has *some* non-null tracker to hand out, real or no-op. The throw path only fires if the provider itself is missing from the tree, not if Supabase is unconfigured.
+
+## Testing
+
+- Unit test the extracted `assertPresenceTracker` helper directly: throws with the expected message when passed `null`; returns the tracker unchanged when passed a valid `IPresenceTracker` (a simple mock object satisfying the interface). Pure function, no rendering needed.
+- No changes needed to the existing heartbeat controller tests or `use-presence.test.ts`'s type-contract tests — removing the two dead guards doesn't change any tested behavior.
+- No unit test exists (or can reasonably exist without jsdom) for "`AppProviders` actually renders `PresenceTrackerProvider` with a working tracker" — that is an integration/rendering fact, covered by manual verification instead.
+- **Manual verification (Playwright, dev server):** join the demo quiz as a player and confirm real `POST /api/quiz/[quizId]/player/[playerId]/presence` requests now appear in the network log within the first ~25s (proving the heartbeat runs at all — the thing that was silently broken). Then run PR #58's originally-planned Task 4 script: simulate a `/presence` 500, confirm `ConnectionStatusBanner` shows "Connection lost. Trying to reconnect...", revert, confirm recovery and the "✓ Reconnected!" toast.
+
+## Risk / rollout
+
+Very low risk. Mounting a provider that was never mounted before is purely additive — it cannot regress any existing behavior, since nothing was depending on the tracker being `null`. The fail-loud change only activates on a code path (missing provider) that, after this fix, should never occur in the running app; it exists purely as a regression guard for the future. No feature flag needed.
+
+## Decision Log
+
+**Decision: mount globally in `AppProviders`, not scoped to the player route group**
+Considered adding the provider only within a layout for `(player)/play/[quizId]/[playerId]`, since presence tracking is only consumed by player-facing components. Rejected in favor of matching `RealtimeClientProvider`'s existing global-mount pattern exactly — consistency with the established DI convention in this codebase outweighs the marginal benefit of narrower scoping, and it keeps both realtime mechanisms wired the same way.
+
+**Decision: fail loud (throw) instead of leaving `usePresenceTracker()` nullable**
+Considered leaving the hook's nullable return type as-is and only fixing the missing mount. Rejected because the nullable-and-silently-ignored return type is *why* this bug went undetected for as long as it did — the sibling `useRealtimeClient()` already throws in the equivalent situation, and no test or code in this repo relies on `usePresenceTracker()` returning `null`, so hardening it costs nothing and closes off this entire bug class going forward.

--- a/docs/progress/plans/2026-07-05-presence-tracker-provider-implementation.md
+++ b/docs/progress/plans/2026-07-05-presence-tracker-provider-implementation.md
@@ -1,0 +1,567 @@
+# Presence Tracker Provider Mounting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Mount `PresenceTrackerProvider` (built in Phase 4.1, never wired up) so the presence heartbeat actually runs in production, and harden `usePresenceTracker()` to fail loud so this exact bug class — a hook silently no-op'ing because its provider was never mounted — can't recur undetected.
+
+**Architecture:** Two small, independent, pattern-matching changes. First, mount `PresenceTrackerProvider` in `AppProviders` (`src/app/providers.tsx`) using the existing `getPresenceTracker()` factory, exactly mirroring how `RealtimeClientProvider` is already mounted there for the sibling realtime mechanism. Second, harden `usePresenceTracker()` (`src/hooks/use-presence.tsx`) to throw when the provider is missing — matching the sibling `useRealtimeClient()`'s existing fail-loud behavior — by extracting the throw into a plain, unit-testable `assertPresenceTracker` function, then remove the two now-dead `if (!tracker) return` guards this makes unreachable.
+
+**Tech Stack:** TypeScript, React 19 hooks/context, Vitest, no new dependencies.
+
+## Global Constraints
+
+- No changes to `getPresenceTracker()`'s caching, `NoopPresenceTracker` fallback, or Supabase client construction (`src/infrastructure/realtime/presence-tracker.ts`) — already correct.
+- No changes to the heartbeat controller, retry/backoff/circuit-breaker logic, or cadence (`src/lib/presence-heartbeat-controller.ts`) — already fixed and verified in PR #58.
+- No changes to `useReconnection`, `ConnectionStatusBanner`, or `connection-status.ts`.
+- Mount the provider globally in `AppProviders`, not scoped to a route group — matches the existing `RealtimeClientProvider` pattern.
+- `usePresenceTracker()`'s throw logic must be extracted into a plain function (`assertPresenceTracker`) so it's unit-testable without rendering — this repo has no jsdom/renderHook infra.
+
+---
+
+### Task 1: Mount `PresenceTrackerProvider` in `AppProviders`
+
+**Files:**
+- Modify: `src/app/providers.tsx`
+
+**Interfaces:**
+- Consumes: `PresenceTrackerProvider` (exported from `@hooks/use-presence`, unchanged signature: `{ tracker: IPresenceTracker; children: ReactNode }`); `getPresenceTracker` (exported from `@infrastructure/realtime/presence-tracker`, unchanged signature: `(): IPresenceTracker`).
+- Produces: every component under `AppProviders` (i.e. the whole app) can now call `usePresence`/`usePresenceTracker` and receive a real (or no-op, if Supabase env vars are missing) tracker instead of `null`.
+
+There is no unit test for this file today (it's a rendering-only wiring file with no branching logic — the same is true of the pre-existing `RealtimeClientProvider` mount it mirrors), so this task is verified via typecheck, lint, and the full test suite, not a new test.
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace `src/app/providers.tsx` entirely with:
+
+```tsx
+'use client';
+
+import { ReactNode, useMemo, useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import dynamic from 'next/dynamic';
+import { RealtimeClientProvider } from '@hooks/use-realtime-client';
+import { PresenceTrackerProvider } from '@hooks/use-presence';
+
+const ReactQueryDevtools = dynamic(
+  () =>
+    import('@tanstack/react-query-devtools').then(
+      (mod) => mod.ReactQueryDevtools
+    ),
+  { ssr: false }
+);
+import { createNoopRealtimeClient } from '@infrastructure/realtime/noop-realtime-client';
+import { createSupabaseRealtimeClient } from '@infrastructure/realtime/supabase-realtime-client';
+import { getPresenceTracker } from '@infrastructure/realtime/presence-tracker';
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        refetchOnWindowFocus: false,
+        retry: 1,
+      },
+      mutations: {
+        retry: 1,
+      },
+    },
+  });
+
+export function AppProviders({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(createQueryClient);
+  const [presenceTracker] = useState(getPresenceTracker);
+  const realtimeClient = useMemo(() => {
+    return createSupabaseRealtimeClient() ?? createNoopRealtimeClient();
+  }, []);
+
+  return (
+    <PresenceTrackerProvider tracker={presenceTracker}>
+      <RealtimeClientProvider client={realtimeClient}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+          {process.env.NODE_ENV !== 'production' && (
+            <ReactQueryDevtools buttonPosition="bottom-left" />
+          )}
+        </QueryClientProvider>
+      </RealtimeClientProvider>
+    </PresenceTrackerProvider>
+  );
+}
+```
+
+`useState(getPresenceTracker)` uses React's lazy-initializer form (same pattern already used one line above for `useState(createQueryClient)`), so `getPresenceTracker()` runs exactly once per `AppProviders` instance. `getPresenceTracker()` itself also caches a module-level singleton, so this is safe even if `AppProviders` were ever remounted.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `yarn test`
+Expected: PASS — no regressions. No test currently exercises `AppProviders` directly (no jsdom/renderHook), so nothing here should change test output.
+
+- [ ] **Step 3: Run lint and build**
+
+Run: `yarn lint`
+Expected: 0 errors
+
+Run: `yarn build`
+Expected: succeeds (this also typechecks — confirms `PresenceTrackerProvider`'s `tracker` prop type matches `getPresenceTracker()`'s return type)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/providers.tsx
+git commit -m "fix: mount PresenceTrackerProvider so the presence heartbeat actually runs
+
+PresenceTrackerProvider was built in Phase 4.1 alongside the rest of
+the presence-tracking foundation but was never mounted anywhere in
+src/app, unlike the sibling RealtimeClientProvider. usePresenceTracker()
+therefore always returned null, so usePresence's mount effect never
+started the heartbeat controller (track() or persist()) for any
+player, in any environment -- independent of the heartbeat resilience
+fix in PR #58."
+```
+
+---
+
+### Task 2: Harden `usePresenceTracker()` to fail loud
+
+**Files:**
+- Modify: `src/hooks/use-presence.tsx`
+- Modify: `src/tests/hooks/use-presence.test.ts`
+
+**Interfaces:**
+- Produces: `assertPresenceTracker(tracker: IPresenceTracker | null): IPresenceTracker` (new export from `@hooks/use-presence`) — throws `Error('PresenceTrackerProvider is missing from the component tree.')` if `tracker` is falsy, otherwise returns it unchanged.
+- Produces: `usePresenceTracker(): IPresenceTracker` — return type changes from `IPresenceTracker | null` to `IPresenceTracker` (no consumers outside this file exist today, confirmed by repo-wide search, so this is a safe signature tightening).
+- Consumes: `IPresenceTracker` (unchanged, from `@infrastructure/realtime/presence-tracker`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add these imports and this new `describe` block to `src/tests/hooks/use-presence.test.ts` — full new file contents:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import type {
+  UsePresenceOptions,
+  UsePresenceReturn,
+} from '@hooks/use-presence';
+import { assertPresenceTracker } from '@hooks/use-presence';
+import type { IPresenceTracker } from '@infrastructure/realtime/presence-tracker';
+
+/**
+ * Type-contract tests for usePresence's public API.
+ *
+ * Retry/backoff/circuit-breaker/cadence behavior is covered by
+ * src/tests/lib/presence-heartbeat-controller.test.ts, since this repo has
+ * no jsdom/renderHook infra to exercise the hook's timing logic directly.
+ */
+
+describe('usePresence', () => {
+  describe('Type Contracts', () => {
+    it('should define UsePresenceOptions with all required fields', () => {
+      const mockOptions: UsePresenceOptions = {
+        quizId: 'quiz-123',
+        playerId: 'player-456',
+        playerName: 'Test Player',
+        persistToDatabase: true,
+        onSync: () => {},
+        onJoin: () => {},
+        onLeave: () => {},
+        onConnectionError: () => {},
+        onReconnected: () => {},
+      };
+
+      expect(mockOptions).toHaveProperty('quizId');
+      expect(mockOptions).toHaveProperty('playerId');
+      expect(mockOptions).toHaveProperty('playerName');
+      expect(mockOptions).toHaveProperty('persistToDatabase');
+      expect(mockOptions).toHaveProperty('onSync');
+      expect(mockOptions).toHaveProperty('onJoin');
+      expect(mockOptions).toHaveProperty('onLeave');
+      expect(mockOptions).toHaveProperty('onConnectionError');
+      expect(mockOptions).toHaveProperty('onReconnected');
+    });
+
+    it('should define UsePresenceReturn with connection state', () => {
+      const mockReturn: UsePresenceReturn = {
+        isConnected: true,
+        presenceState: {},
+        sendHeartbeat: async () => {},
+        failureCount: 0,
+        lastSuccessfulHeartbeat: '2026-01-31T12:00:00Z',
+      };
+
+      expect(mockReturn).toHaveProperty('isConnected');
+      expect(mockReturn).toHaveProperty('presenceState');
+      expect(mockReturn).toHaveProperty('sendHeartbeat');
+      expect(mockReturn).toHaveProperty('failureCount');
+      expect(mockReturn).toHaveProperty('lastSuccessfulHeartbeat');
+
+      expect(typeof mockReturn.isConnected).toBe('boolean');
+      expect(typeof mockReturn.presenceState).toBe('object');
+      expect(typeof mockReturn.sendHeartbeat).toBe('function');
+      expect(typeof mockReturn.failureCount).toBe('number');
+      expect(
+        typeof mockReturn.lastSuccessfulHeartbeat === 'string' ||
+          mockReturn.lastSuccessfulHeartbeat === null
+      ).toBe(true);
+    });
+
+    it('should support optional callback props', () => {
+      const minimalOptions: UsePresenceOptions = {
+        quizId: 'quiz-123',
+        playerId: 'player-456',
+        playerName: 'Test Player',
+      };
+
+      expect(minimalOptions.persistToDatabase).toBeUndefined();
+      expect(minimalOptions.onSync).toBeUndefined();
+      expect(minimalOptions.onJoin).toBeUndefined();
+      expect(minimalOptions.onLeave).toBeUndefined();
+      expect(minimalOptions.onConnectionError).toBeUndefined();
+      expect(minimalOptions.onReconnected).toBeUndefined();
+    });
+  });
+
+  describe('assertPresenceTracker', () => {
+    it('throws when the tracker is null', () => {
+      expect(() => assertPresenceTracker(null)).toThrow(
+        'PresenceTrackerProvider is missing from the component tree.'
+      );
+    });
+
+    it('returns the tracker unchanged when it is not null', () => {
+      const mockTracker: IPresenceTracker = {
+        subscribe: () => () => {},
+        track: async () => {},
+        untrack: async () => {},
+        getPresenceState: () => ({}),
+        disconnect: () => {},
+      };
+
+      expect(assertPresenceTracker(mockTracker)).toBe(mockTracker);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `yarn test use-presence`
+Expected: FAIL — `assertPresenceTracker` is not yet exported from `@hooks/use-presence`, so the import resolves to `undefined`; calling it throws a runtime `TypeError` ("assertPresenceTracker is not a function").
+
+- [ ] **Step 3: Implement `assertPresenceTracker` and harden `usePresenceTracker`**
+
+Replace `src/hooks/use-presence.tsx` entirely with:
+
+```tsx
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import type {
+  IPresenceTracker,
+  PresenceState,
+} from '@infrastructure/realtime/presence-tracker';
+import { createPresenceHeartbeatController } from '@lib/presence-heartbeat-controller';
+
+const PresenceTrackerContext = createContext<IPresenceTracker | null>(null);
+
+export type PresenceTrackerProviderProps = {
+  tracker: IPresenceTracker;
+  children: ReactNode;
+};
+
+export const PresenceTrackerProvider = ({
+  tracker,
+  children,
+}: PresenceTrackerProviderProps) => (
+  <PresenceTrackerContext.Provider value={tracker}>
+    {children}
+  </PresenceTrackerContext.Provider>
+);
+
+/**
+ * Throws if the tracker is missing instead of silently returning null.
+ * Extracted as a plain function so it's unit-testable without rendering
+ * (this repo has no jsdom/renderHook infra).
+ */
+export const assertPresenceTracker = (
+  tracker: IPresenceTracker | null
+): IPresenceTracker => {
+  if (!tracker) {
+    throw new Error(
+      'PresenceTrackerProvider is missing from the component tree.'
+    );
+  }
+  return tracker;
+};
+
+export const usePresenceTracker = (): IPresenceTracker => {
+  return assertPresenceTracker(useContext(PresenceTrackerContext));
+};
+
+export type UsePresenceOptions = {
+  quizId: string;
+  playerId: string;
+  playerName: string;
+  /** Whether to persist presence to database (calls API endpoint) */
+  persistToDatabase?: boolean;
+  /** Called when presence sync occurs with all connected players */
+  onSync?: (presences: Record<string, PresenceState[]>) => void;
+  /** Called when a player joins */
+  onJoin?: (presences: PresenceState[]) => void;
+  /** Called when a player leaves */
+  onLeave?: (presences: PresenceState[]) => void;
+  /** Called after maxRetryAttempts consecutive heartbeat failures */
+  onConnectionError?: () => void;
+  /** Called when a heartbeat succeeds after previous failures */
+  onReconnected?: () => void;
+};
+
+export type UsePresenceReturn = {
+  /** Whether the presence connection is active */
+  isConnected: boolean;
+  /** Current presence state for all players */
+  presenceState: Record<string, PresenceState[]>;
+  /** Manually send an immediate track + persist attempt */
+  sendHeartbeat: () => Promise<void>;
+  /** Number of consecutive heartbeat failures */
+  failureCount: number;
+  /** Timestamp of last successful heartbeat */
+  lastSuccessfulHeartbeat: string | null;
+};
+
+/**
+ * Hook for tracking player presence in a quiz.
+ * Joins the presence channel on mount, runs the heartbeat controller's
+ * track/persist loops, and cleans up on unmount.
+ */
+export const usePresence = ({
+  quizId,
+  playerId,
+  playerName,
+  persistToDatabase = false,
+  onSync,
+  onJoin,
+  onLeave,
+  onConnectionError,
+  onReconnected,
+}: UsePresenceOptions): UsePresenceReturn => {
+  const tracker = usePresenceTracker();
+  const [isConnected, setIsConnected] = useState(false);
+  const [presenceState, setPresenceState] = useState<
+    Record<string, PresenceState[]>
+  >({});
+  const [failureCount, setFailureCount] = useState(0);
+  const [lastSuccessfulHeartbeat, setLastSuccessfulHeartbeat] = useState<
+    string | null
+  >(null);
+  const joinedAtRef = useRef<string>(new Date().toISOString());
+
+  // Latest-value refs so the controller's track/persist functions and
+  // callbacks never close over stale props, without needing to recreate
+  // the controller (and restart its timers) on every render. Synced in a
+  // layout effect (not during render, since refs must not be written while
+  // rendering per react-hooks/refs) so the mirroring happens synchronously
+  // in the commit phase, before the controller's setTimeout-driven ticks
+  // can fire against a stale ref value.
+  const latestRef = useRef({
+    tracker,
+    quizId,
+    playerId,
+    playerName,
+    persistToDatabase,
+  });
+  const onConnectionErrorRef = useRef(onConnectionError);
+  const onReconnectedRef = useRef(onReconnected);
+
+  useLayoutEffect(() => {
+    latestRef.current = {
+      tracker,
+      quizId,
+      playerId,
+      playerName,
+      persistToDatabase,
+    };
+    onConnectionErrorRef.current = onConnectionError;
+    onReconnectedRef.current = onReconnected;
+  });
+
+  const track = useCallback(async () => {
+    const current = latestRef.current;
+    await current.tracker.track(current.quizId, {
+      playerId: current.playerId,
+      playerName: current.playerName,
+      joinedAt: joinedAtRef.current,
+    });
+  }, []);
+
+  const persist = useCallback(async () => {
+    const current = latestRef.current;
+    if (!current.persistToDatabase) return;
+
+    const response = await fetch(
+      `/api/quiz/${current.quizId}/player/${current.playerId}/presence`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ timestamp: new Date().toISOString() }),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Presence persist request failed with status ${response.status}`
+      );
+    }
+  }, []);
+
+  const controllerRef = useRef<ReturnType<
+    typeof createPresenceHeartbeatController
+  > | null>(null);
+
+  // Create the controller once on mount. Done in a layout effect (not
+  // directly in the render body) since refs must not be written while
+  // rendering; using useLayoutEffect (rather than a passive effect) ensures
+  // the controller exists synchronously in the commit phase, before any
+  // other timing-sensitive effects below can run. The ref-null check keeps
+  // this a one-time initialization even under StrictMode's double-invoke.
+  useLayoutEffect(() => {
+    if (controllerRef.current === null) {
+      controllerRef.current = createPresenceHeartbeatController(
+        track,
+        persist,
+        {
+          onFailureCountChange: setFailureCount,
+          onSuccess: setLastSuccessfulHeartbeat,
+          onConnectionError: () => onConnectionErrorRef.current?.(),
+          onReconnected: () => onReconnectedRef.current?.(),
+        }
+      );
+    }
+  }, [track, persist]);
+
+  // Subscribe to presence and start the heartbeat controller on mount.
+  useEffect(() => {
+    const unsubscribe = tracker.subscribe(quizId, playerId, {
+      onSync: (state) => {
+        setPresenceState(state);
+        setIsConnected(true);
+        onSync?.(state);
+      },
+      onJoin: (presences) => {
+        setPresenceState(tracker.getPresenceState(quizId));
+        onJoin?.(presences);
+      },
+      onLeave: (presences) => {
+        setPresenceState(tracker.getPresenceState(quizId));
+        onLeave?.(presences);
+      },
+    });
+
+    controllerRef.current?.start({ persistEnabled: persistToDatabase });
+
+    return () => {
+      controllerRef.current?.stop();
+      void tracker.untrack(quizId);
+      unsubscribe();
+      setIsConnected(false);
+    };
+    // onSync/onJoin/onLeave intentionally included to match prior behavior;
+    // track/persist/controller are stable across renders (see refs above).
+  }, [tracker, quizId, playerId, persistToDatabase, onSync, onJoin, onLeave]);
+
+  return {
+    isConnected,
+    presenceState,
+    sendHeartbeat: () =>
+      controllerRef.current?.sendImmediate() ?? Promise.resolve(),
+    failureCount,
+    lastSuccessfulHeartbeat,
+  };
+};
+```
+
+Changes from the pre-existing file:
+- Added `assertPresenceTracker` (exported) and rewired `usePresenceTracker` to use it.
+- `usePresenceTracker`'s return type is now `IPresenceTracker` (was `IPresenceTracker | null`).
+- Removed `if (!current.tracker) return;` from `track()` — unreachable now that `tracker` can't be `null`.
+- Removed `if (!tracker) return;` from the subscribe/start effect — unreachable for the same reason.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `yarn test use-presence`
+Expected: PASS (5 tests: 3 existing type-contract tests + 2 new `assertPresenceTracker` tests)
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `yarn test`
+Expected: PASS, no regressions (in particular, `presence-heartbeat-controller.test.ts` and any test importing `@hooks/use-presence` types should be unaffected — `UsePresenceOptions`/`UsePresenceReturn` are unchanged).
+
+- [ ] **Step 6: Run lint and build**
+
+Run: `yarn lint`
+Expected: 0 errors
+
+Run: `yarn build`
+Expected: succeeds
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hooks/use-presence.tsx src/tests/hooks/use-presence.test.ts
+git commit -m "fix: harden usePresenceTracker to fail loud instead of returning null
+
+Extracts assertPresenceTracker, a plain unit-testable function that
+throws when the provider is missing, matching the sibling
+useRealtimeClient()'s existing fail-loud behavior. Removes the two
+if (!tracker) return guards in usePresence that this makes
+unreachable. No consumers outside this file relied on the nullable
+return (confirmed by repo-wide search), so this is a safe tightening."
+```
+
+---
+
+### Task 3: Manual verification
+
+Not a code change — confirms the heartbeat actually runs now (the core bug), then re-runs PR #58's originally-planned failure-simulation verification, which was blocked by this exact bug.
+
+- [ ] **Step 1: Confirm the heartbeat now actually fires**
+
+With the dev server running (picking up Tasks 1-2), navigate to `/join`, enter join code `TRYBOBR` (the `Bobr Quiz Demo` quiz), pick a name, join. Using the Playwright MCP's network-requests tool, confirm at least one `POST /api/quiz/[quizId]/player/[playerId]/presence` request appears within the first ~25s (the persist cadence is `20_000` ± up to `5_000` jitter). This is the concrete proof the root bug is fixed — before this plan, zero such requests were ever observed.
+
+- [ ] **Step 2: Simulate a persistence failure**
+
+Temporarily edit `src/app/api/quiz/[quizId]/player/[playerId]/presence/route.ts` to force a failure — add as the first line inside the `POST` handler:
+
+```typescript
+return NextResponse.json({ error: 'simulated' }, { status: 500 });
+```
+
+Save and let the dev server hot-reload.
+
+- [ ] **Step 3: Confirm the player sees the reconnecting banner**
+
+Within ~30s (5 fast retries: 1+2+4+8+8s), the `ConnectionStatusBanner` should appear on the player screen showing "Connection lost. Trying to reconnect..." — confirm via a Playwright snapshot.
+
+- [ ] **Step 4: Confirm recovery**
+
+Revert the temporary change from Step 2, save. Within the next persist attempt (circuit-open cadence, 30s), confirm the banner clears and shows "✓ Reconnected! Your session has been restored."
+
+- [ ] **Step 5: Confirm the host's view was sensible throughout**
+
+Check the host dashboard's Players panel during the simulated outage — the player should age through away/disconnected on the same schedule as before, then reflect the recovery once heartbeats resume.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** All 4 in-scope items from the design spec are covered — Task 1 mounts the provider (item 1); Task 2 hardens `usePresenceTracker` and removes the dead guards (items 2-3); Task 3 runs the deferred manual verification plus the new "heartbeat actually fires" check (item 4).
+- **Placeholder scan:** No TBD/TODO; every step has complete, runnable code.
+- **Type consistency:** `assertPresenceTracker(tracker: IPresenceTracker | null): IPresenceTracker` and `usePresenceTracker(): IPresenceTracker` in Task 2 match exactly what Task 1's `AppProviders` consumes (`PresenceTrackerProvider`'s existing, unchanged `{ tracker: IPresenceTracker; ... }` prop type). No other file in the repo calls `usePresenceTracker()` (confirmed via repo-wide search before writing this plan), so Task 2's signature change has no other call sites to update.

--- a/docs/progress/plans/2026-07-05-presence-tracker-provider-implementation.md
+++ b/docs/progress/plans/2026-07-05-presence-tracker-provider-implementation.md
@@ -1,5 +1,7 @@
 # Presence Tracker Provider Mounting Implementation Plan
 
+**Status:** ✅ Complete — merged via [PR #59](https://github.com/Banych/bobrquiz/pull/59)
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Mount `PresenceTrackerProvider` (built in Phase 4.1, never wired up) so the presence heartbeat actually runs in production, and harden `usePresenceTracker()` to fail loud so this exact bug class — a hook silently no-op'ing because its provider was never mounted — can't recur undetected.
@@ -29,7 +31,7 @@
 
 There is no unit test for this file today (it's a rendering-only wiring file with no branching logic — the same is true of the pre-existing `RealtimeClientProvider` mount it mirrors), so this task is verified via typecheck, lint, and the full test suite, not a new test.
 
-- [ ] **Step 1: Replace the file contents**
+- [x] **Step 1: Replace the file contents**
 
 Replace `src/app/providers.tsx` entirely with:
 
@@ -91,12 +93,12 @@ export function AppProviders({ children }: { children: ReactNode }) {
 
 `useState(getPresenceTracker)` uses React's lazy-initializer form (same pattern already used one line above for `useState(createQueryClient)`), so `getPresenceTracker()` runs exactly once per `AppProviders` instance. `getPresenceTracker()` itself also caches a module-level singleton, so this is safe even if `AppProviders` were ever remounted.
 
-- [ ] **Step 2: Run the full test suite**
+- [x] **Step 2: Run the full test suite**
 
 Run: `yarn test`
 Expected: PASS — no regressions. No test currently exercises `AppProviders` directly (no jsdom/renderHook), so nothing here should change test output.
 
-- [ ] **Step 3: Run lint and build**
+- [x] **Step 3: Run lint and build**
 
 Run: `yarn lint`
 Expected: 0 errors
@@ -104,7 +106,7 @@ Expected: 0 errors
 Run: `yarn build`
 Expected: succeeds (this also typechecks — confirms `PresenceTrackerProvider`'s `tracker` prop type matches `getPresenceTracker()`'s return type)
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src/app/providers.tsx
@@ -132,7 +134,7 @@ fix in PR #58."
 - Produces: `usePresenceTracker(): IPresenceTracker` — return type changes from `IPresenceTracker | null` to `IPresenceTracker` (no consumers outside this file exist today, confirmed by repo-wide search, so this is a safe signature tightening).
 - Consumes: `IPresenceTracker` (unchanged, from `@infrastructure/realtime/presence-tracker`).
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add these imports and this new `describe` block to `src/tests/hooks/use-presence.test.ts` — full new file contents:
 
@@ -242,12 +244,12 @@ describe('usePresence', () => {
 });
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `yarn test use-presence`
 Expected: FAIL — `assertPresenceTracker` is not yet exported from `@hooks/use-presence`, so the import resolves to `undefined`; calling it throws a runtime `TypeError` ("assertPresenceTracker is not a function").
 
-- [ ] **Step 3: Implement `assertPresenceTracker` and harden `usePresenceTracker`**
+- [x] **Step 3: Implement `assertPresenceTracker` and harden `usePresenceTracker`**
 
 Replace `src/hooks/use-presence.tsx` entirely with:
 
@@ -494,17 +496,17 @@ Changes from the pre-existing file:
 - Removed `if (!current.tracker) return;` from `track()` — unreachable now that `tracker` can't be `null`.
 - Removed `if (!tracker) return;` from the subscribe/start effect — unreachable for the same reason.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `yarn test use-presence`
 Expected: PASS (5 tests: 3 existing type-contract tests + 2 new `assertPresenceTracker` tests)
 
-- [ ] **Step 5: Run the full test suite**
+- [x] **Step 5: Run the full test suite**
 
 Run: `yarn test`
 Expected: PASS, no regressions (in particular, `presence-heartbeat-controller.test.ts` and any test importing `@hooks/use-presence` types should be unaffected — `UsePresenceOptions`/`UsePresenceReturn` are unchanged).
 
-- [ ] **Step 6: Run lint and build**
+- [x] **Step 6: Run lint and build**
 
 Run: `yarn lint`
 Expected: 0 errors
@@ -512,7 +514,7 @@ Expected: 0 errors
 Run: `yarn build`
 Expected: succeeds
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add src/hooks/use-presence.tsx src/tests/hooks/use-presence.test.ts
@@ -532,11 +534,13 @@ return (confirmed by repo-wide search), so this is a safe tightening."
 
 Not a code change — confirms the heartbeat actually runs now (the core bug), then re-runs PR #58's originally-planned failure-simulation verification, which was blocked by this exact bug.
 
-- [ ] **Step 1: Confirm the heartbeat now actually fires**
+**Note:** the first attempt at this task (joining the demo quiz) immediately surfaced a second, independent bug — `SupabasePresenceTracker.subscribe()` crashing on remount, since this was the first time the heartbeat mechanism ever actually ran. That bug was fixed in a follow-up plan (`docs/progress/plans/2026-07-05-presence-channel-reuse-implementation.md`), whose own Task 2 completed all 5 steps below for real, on the fixed code. Checked off here since the verification this task specifies was genuinely performed, just as part of the follow-up plan's manual verification rather than in isolation immediately after Task 2.
+
+- [x] **Step 1: Confirm the heartbeat now actually fires**
 
 With the dev server running (picking up Tasks 1-2), navigate to `/join`, enter join code `TRYBOBR` (the `Bobr Quiz Demo` quiz), pick a name, join. Using the Playwright MCP's network-requests tool, confirm at least one `POST /api/quiz/[quizId]/player/[playerId]/presence` request appears within the first ~25s (the persist cadence is `20_000` ± up to `5_000` jitter). This is the concrete proof the root bug is fixed — before this plan, zero such requests were ever observed.
 
-- [ ] **Step 2: Simulate a persistence failure**
+- [x] **Step 2: Simulate a persistence failure**
 
 Temporarily edit `src/app/api/quiz/[quizId]/player/[playerId]/presence/route.ts` to force a failure — add as the first line inside the `POST` handler:
 
@@ -546,15 +550,15 @@ return NextResponse.json({ error: 'simulated' }, { status: 500 });
 
 Save and let the dev server hot-reload.
 
-- [ ] **Step 3: Confirm the player sees the reconnecting banner**
+- [x] **Step 3: Confirm the player sees the reconnecting banner**
 
 Within ~30s (5 fast retries: 1+2+4+8+8s), the `ConnectionStatusBanner` should appear on the player screen showing "Connection lost. Trying to reconnect..." — confirm via a Playwright snapshot.
 
-- [ ] **Step 4: Confirm recovery**
+- [x] **Step 4: Confirm recovery**
 
 Revert the temporary change from Step 2, save. Within the next persist attempt (circuit-open cadence, 30s), confirm the banner clears and shows "✓ Reconnected! Your session has been restored."
 
-- [ ] **Step 5: Confirm the host's view was sensible throughout**
+- [x] **Step 5: Confirm the host's view was sensible throughout**
 
 Check the host dashboard's Players panel during the simulated outage — the player should age through away/disconnected on the same schedule as before, then reflect the recovery once heartbeats resume.
 

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useMemo, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
 import { RealtimeClientProvider } from '@hooks/use-realtime-client';
+import { PresenceTrackerProvider } from '@hooks/use-presence';
 
 const ReactQueryDevtools = dynamic(
   () =>
@@ -14,6 +15,7 @@ const ReactQueryDevtools = dynamic(
 );
 import { createNoopRealtimeClient } from '@infrastructure/realtime/noop-realtime-client';
 import { createSupabaseRealtimeClient } from '@infrastructure/realtime/supabase-realtime-client';
+import { getPresenceTracker } from '@infrastructure/realtime/presence-tracker';
 
 const createQueryClient = () =>
   new QueryClient({
@@ -31,18 +33,21 @@ const createQueryClient = () =>
 
 export function AppProviders({ children }: { children: ReactNode }) {
   const [queryClient] = useState(createQueryClient);
+  const [presenceTracker] = useState(getPresenceTracker);
   const realtimeClient = useMemo(() => {
     return createSupabaseRealtimeClient() ?? createNoopRealtimeClient();
   }, []);
 
   return (
-    <RealtimeClientProvider client={realtimeClient}>
-      <QueryClientProvider client={queryClient}>
-        {children}
-        {process.env.NODE_ENV !== 'production' && (
-          <ReactQueryDevtools buttonPosition="bottom-left" />
-        )}
-      </QueryClientProvider>
-    </RealtimeClientProvider>
+    <PresenceTrackerProvider tracker={presenceTracker}>
+      <RealtimeClientProvider client={realtimeClient}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+          {process.env.NODE_ENV !== 'production' && (
+            <ReactQueryDevtools buttonPosition="bottom-left" />
+          )}
+        </QueryClientProvider>
+      </RealtimeClientProvider>
+    </PresenceTrackerProvider>
   );
 }

--- a/src/hooks/use-presence.tsx
+++ b/src/hooks/use-presence.tsx
@@ -32,8 +32,24 @@ export const PresenceTrackerProvider = ({
   </PresenceTrackerContext.Provider>
 );
 
-export const usePresenceTracker = (): IPresenceTracker | null => {
-  return useContext(PresenceTrackerContext);
+/**
+ * Throws if the tracker is missing instead of silently returning null.
+ * Extracted as a plain function so it's unit-testable without rendering
+ * (this repo has no jsdom/renderHook infra).
+ */
+export const assertPresenceTracker = (
+  tracker: IPresenceTracker | null
+): IPresenceTracker => {
+  if (!tracker) {
+    throw new Error(
+      'PresenceTrackerProvider is missing from the component tree.'
+    );
+  }
+  return tracker;
+};
+
+export const usePresenceTracker = (): IPresenceTracker => {
+  return assertPresenceTracker(useContext(PresenceTrackerContext));
 };
 
 export type UsePresenceOptions = {
@@ -125,7 +141,6 @@ export const usePresence = ({
 
   const track = useCallback(async () => {
     const current = latestRef.current;
-    if (!current.tracker) return;
     await current.tracker.track(current.quizId, {
       playerId: current.playerId,
       playerName: current.playerName,
@@ -180,8 +195,6 @@ export const usePresence = ({
 
   // Subscribe to presence and start the heartbeat controller on mount.
   useEffect(() => {
-    if (!tracker) return;
-
     const unsubscribe = tracker.subscribe(quizId, playerId, {
       onSync: (state) => {
         setPresenceState(state);

--- a/src/infrastructure/realtime/presence-tracker.ts
+++ b/src/infrastructure/realtime/presence-tracker.ts
@@ -135,6 +135,8 @@ export class SupabasePresenceTracker implements IPresenceTracker {
         clearTimeout(entry.teardownTimer);
         entry.teardownTimer = null;
       }
+      // Merges (not replaces) so a caller must supply every handler it wants
+      // active on reuse -- an omitted key keeps the previous subscriber's handler.
       Object.assign(entry.handlers, options);
     } else {
       const channelName = getChannelName(quizId);
@@ -185,6 +187,10 @@ export class SupabasePresenceTracker implements IPresenceTracker {
     return () => {
       const current = this.channels.get(quizId);
       if (!current) return;
+
+      if (current.teardownTimer !== null) {
+        clearTimeout(current.teardownTimer);
+      }
 
       current.teardownTimer = setTimeout(() => {
         this.channels.delete(quizId);

--- a/src/infrastructure/realtime/presence-tracker.ts
+++ b/src/infrastructure/realtime/presence-tracker.ts
@@ -74,6 +74,21 @@ const PRESENCE_CHANNEL_PREFIX = 'presence:quiz:';
 const getChannelName = (quizId: string): string =>
   `${PRESENCE_CHANNEL_PREFIX}${quizId}`;
 
+/**
+ * How long to keep a channel alive after its last subscriber unsubscribes,
+ * before actually tearing it down. Survives quick remounts (React Strict
+ * Mode's dev-only double-invoke of effects, or any real fast remount)
+ * without re-calling `.on()` on an already-subscribed channel, which
+ * Supabase's realtime-js throws on.
+ */
+const UNSUBSCRIBE_GRACE_PERIOD_MS = 3_000;
+
+type ChannelEntry = {
+  channel: RealtimeChannel;
+  handlers: PresenceSubscribeOptions;
+  teardownTimer: ReturnType<typeof setTimeout> | null;
+};
+
 const logPresenceIssue = (
   level: 'warn' | 'error',
   message: string,
@@ -89,10 +104,20 @@ const logPresenceIssue = (
 /**
  * Supabase Presence Tracker implementation.
  * Uses Supabase Realtime Presence API to track player connections.
+ *
+ * Channels are kept alive for UNSUBSCRIBE_GRACE_PERIOD_MS after their last
+ * subscriber unsubscribes, so a quick remount (React Strict Mode's
+ * dev-only double-invoke, or any real fast remount) reuses the same
+ * channel instead of racing its async teardown. Supabase's own realtime-js
+ * client dedupes channels by topic internally and only releases a topic
+ * asynchronously (via a close handshake), so recreating a channel for the
+ * same topic before that completes would hand back the same,
+ * already-subscribed object -- this is why reuse, not a faster teardown,
+ * is the fix.
  */
-class SupabasePresenceTracker implements IPresenceTracker {
+export class SupabasePresenceTracker implements IPresenceTracker {
   private readonly client: SupabaseClient;
-  private readonly channels: Map<string, RealtimeChannel> = new Map();
+  private readonly channels: Map<string, ChannelEntry> = new Map();
 
   constructor(client: SupabaseClient) {
     this.client = client;
@@ -103,75 +128,80 @@ class SupabasePresenceTracker implements IPresenceTracker {
     playerId: string,
     options: PresenceSubscribeOptions
   ): () => void {
-    const channelName = getChannelName(quizId);
+    let entry = this.channels.get(quizId);
 
-    // Reuse existing channel if already subscribed
-    let channel = this.channels.get(quizId);
-    if (!channel) {
-      channel = this.client.channel(channelName, {
+    if (entry) {
+      if (entry.teardownTimer !== null) {
+        clearTimeout(entry.teardownTimer);
+        entry.teardownTimer = null;
+      }
+      Object.assign(entry.handlers, options);
+    } else {
+      const channelName = getChannelName(quizId);
+      const channel = this.client.channel(channelName, {
         config: {
           presence: {
             key: playerId,
           },
         },
       });
-      this.channels.set(quizId, channel);
-    }
+      const handlers: PresenceSubscribeOptions = { ...options };
 
-    // Set up presence event handlers
-    if (options.onSync) {
       channel.on('presence', { event: 'sync' }, () => {
-        const state = channel!.presenceState<PresenceState>();
-        options.onSync!(state);
+        const state = channel.presenceState<PresenceState>();
+        handlers.onSync?.(state);
       });
-    }
 
-    if (options.onJoin) {
       channel.on(
         'presence',
         { event: 'join' },
         ({ newPresences }: { newPresences: PresenceState[] }) => {
-          options.onJoin!(newPresences);
+          handlers.onJoin?.(newPresences);
         }
       );
-    }
 
-    if (options.onLeave) {
       channel.on(
         'presence',
         { event: 'leave' },
         ({ leftPresences }: { leftPresences: PresenceState[] }) => {
-          options.onLeave!(leftPresences);
+          handlers.onLeave?.(leftPresences);
         }
       );
+
+      channel.subscribe((status) => {
+        if (status !== 'SUBSCRIBED') {
+          logPresenceIssue('warn', 'Presence subscription status changed', {
+            quizId,
+            playerId,
+            status,
+          });
+        }
+      });
+
+      entry = { channel, handlers, teardownTimer: null };
+      this.channels.set(quizId, entry);
     }
 
-    // Subscribe to the channel
-    channel.subscribe((status) => {
-      if (status !== 'SUBSCRIBED') {
-        logPresenceIssue('warn', 'Presence subscription status changed', {
-          quizId,
-          playerId,
-          status,
-        });
-      }
-    });
-
-    // Return unsubscribe function
     return () => {
-      this.unsubscribe(quizId);
+      const current = this.channels.get(quizId);
+      if (!current) return;
+
+      current.teardownTimer = setTimeout(() => {
+        this.channels.delete(quizId);
+        void this.teardownChannel(quizId, current.channel);
+      }, UNSUBSCRIBE_GRACE_PERIOD_MS);
     };
   }
 
   async track(quizId: string, state: PresenceState): Promise<void> {
-    const channel = this.channels.get(quizId);
-    if (!channel) {
+    const entry = this.channels.get(quizId);
+    if (!entry) {
       logPresenceIssue('warn', 'Cannot track: channel not found', { quizId });
       return;
     }
 
     try {
-      await channel.track(state);
+      await entry.channel.track(state);
     } catch (error) {
       logPresenceIssue('error', 'Failed to track presence', {
         quizId,
@@ -182,32 +212,30 @@ class SupabasePresenceTracker implements IPresenceTracker {
   }
 
   async untrack(quizId: string): Promise<void> {
-    const channel = this.channels.get(quizId);
-    if (!channel) {
+    const entry = this.channels.get(quizId);
+    if (!entry) {
       return;
     }
 
     try {
-      await channel.untrack();
+      await entry.channel.untrack();
     } catch (error) {
       logPresenceIssue('warn', 'Failed to untrack presence', { quizId, error });
     }
   }
 
   getPresenceState(quizId: string): Record<string, PresenceState[]> {
-    const channel = this.channels.get(quizId);
-    if (!channel) {
+    const entry = this.channels.get(quizId);
+    if (!entry) {
       return {};
     }
-    return channel.presenceState<PresenceState>();
+    return entry.channel.presenceState<PresenceState>();
   }
 
-  private async unsubscribe(quizId: string): Promise<void> {
-    const channel = this.channels.get(quizId);
-    if (!channel) {
-      return;
-    }
-
+  private async teardownChannel(
+    quizId: string,
+    channel: RealtimeChannel
+  ): Promise<void> {
     try {
       await channel.untrack();
       await channel.unsubscribe();
@@ -216,15 +244,17 @@ class SupabasePresenceTracker implements IPresenceTracker {
         quizId,
         error,
       });
-    } finally {
-      this.channels.delete(quizId);
     }
   }
 
   disconnect(): void {
-    for (const quizId of this.channels.keys()) {
-      void this.unsubscribe(quizId);
+    for (const [quizId, entry] of this.channels) {
+      if (entry.teardownTimer !== null) {
+        clearTimeout(entry.teardownTimer);
+      }
+      void this.teardownChannel(quizId, entry.channel);
     }
+    this.channels.clear();
   }
 }
 

--- a/src/tests/hooks/use-presence.test.ts
+++ b/src/tests/hooks/use-presence.test.ts
@@ -3,6 +3,8 @@ import type {
   UsePresenceOptions,
   UsePresenceReturn,
 } from '@hooks/use-presence';
+import { assertPresenceTracker } from '@hooks/use-presence';
+import type { IPresenceTracker } from '@infrastructure/realtime/presence-tracker';
 
 /**
  * Type-contract tests for usePresence's public API.
@@ -76,6 +78,26 @@ describe('usePresence', () => {
       expect(minimalOptions.onLeave).toBeUndefined();
       expect(minimalOptions.onConnectionError).toBeUndefined();
       expect(minimalOptions.onReconnected).toBeUndefined();
+    });
+  });
+
+  describe('assertPresenceTracker', () => {
+    it('throws when the tracker is null', () => {
+      expect(() => assertPresenceTracker(null)).toThrow(
+        'PresenceTrackerProvider is missing from the component tree.'
+      );
+    });
+
+    it('returns the tracker unchanged when it is not null', () => {
+      const mockTracker: IPresenceTracker = {
+        subscribe: () => () => {},
+        track: async () => {},
+        untrack: async () => {},
+        getPresenceState: () => ({}),
+        disconnect: () => {},
+      };
+
+      expect(assertPresenceTracker(mockTracker)).toBe(mockTracker);
     });
   });
 });

--- a/src/tests/infrastructure/realtime/presence-tracker.test.ts
+++ b/src/tests/infrastructure/realtime/presence-tracker.test.ts
@@ -2,8 +2,10 @@ import {
   type IPresenceTracker,
   type PresenceState,
   type PresenceSubscribeOptions,
+  SupabasePresenceTracker,
 } from '@infrastructure/realtime/presence-tracker';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 /**
  * Mock presence tracker for testing.
@@ -253,5 +255,152 @@ describe('PresenceTracker', () => {
       expect(Object.keys(quiz1State)).toEqual(['player-1']);
       expect(Object.keys(quiz2State)).toEqual(['player-2']);
     });
+  });
+});
+
+/**
+ * Mock Supabase channel/client for testing SupabasePresenceTracker's real
+ * channel reuse/teardown logic (not a stand-in fake -- this exercises the
+ * actual class, mocking only the Supabase client boundary).
+ */
+type MockChannel = {
+  on: ReturnType<typeof vi.fn>;
+  subscribe: ReturnType<typeof vi.fn>;
+  track: ReturnType<typeof vi.fn>;
+  untrack: ReturnType<typeof vi.fn>;
+  unsubscribe: ReturnType<typeof vi.fn>;
+  presenceState: ReturnType<typeof vi.fn>;
+  emit: (event: 'sync' | 'join' | 'leave', payload?: unknown) => void;
+};
+
+const createMockChannel = (): MockChannel => {
+  const listeners = new Map<string, (payload: unknown) => void>();
+
+  return {
+    on: vi.fn(
+      (
+        _type: string,
+        filter: { event: string },
+        callback: (payload: unknown) => void
+      ) => {
+        listeners.set(filter.event, callback);
+      }
+    ),
+    subscribe: vi.fn((callback?: (status: string) => void) => {
+      callback?.('SUBSCRIBED');
+    }),
+    track: vi.fn().mockResolvedValue('ok'),
+    untrack: vi.fn().mockResolvedValue('ok'),
+    unsubscribe: vi.fn().mockResolvedValue('ok'),
+    presenceState: vi.fn().mockReturnValue({}),
+    emit: (event, payload) => {
+      listeners.get(event)?.(payload);
+    },
+  };
+};
+
+const createMockClient = () => {
+  const channelsByName = new Map<string, MockChannel>();
+  const channel = vi.fn((name: string) => {
+    const mockChannel = createMockChannel();
+    channelsByName.set(name, mockChannel);
+    return mockChannel;
+  });
+  return {
+    client: { channel } as unknown as SupabaseClient,
+    channelsByName,
+    channelFn: channel,
+  };
+};
+
+describe('SupabasePresenceTracker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reuses the channel when subscribe is called again within the grace period', () => {
+    const { client, channelsByName, channelFn } = createMockClient();
+    const tracker = new SupabasePresenceTracker(client);
+
+    const unsubscribe1 = tracker.subscribe('quiz-1', 'player-1', {});
+    unsubscribe1();
+
+    tracker.subscribe('quiz-1', 'player-1', {});
+
+    expect(channelFn).toHaveBeenCalledTimes(1);
+    const channel = channelsByName.get('presence:quiz:quiz-1')!;
+    expect(channel.on).toHaveBeenCalledTimes(3);
+    expect(channel.subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a fresh channel when subscribe is called after the grace period elapses', async () => {
+    const { client, channelFn } = createMockClient();
+    const tracker = new SupabasePresenceTracker(client);
+
+    const unsubscribe1 = tracker.subscribe('quiz-1', 'player-1', {});
+    unsubscribe1();
+
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    tracker.subscribe('quiz-1', 'player-1', {});
+
+    expect(channelFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('routes presence events to the latest handlers after a reuse', () => {
+    const { client, channelsByName } = createMockClient();
+    const tracker = new SupabasePresenceTracker(client);
+
+    const onSync1 = vi.fn();
+    const unsubscribe1 = tracker.subscribe('quiz-1', 'player-1', {
+      onSync: onSync1,
+    });
+    unsubscribe1();
+
+    const onSync2 = vi.fn();
+    tracker.subscribe('quiz-1', 'player-1', { onSync: onSync2 });
+
+    const channel = channelsByName.get('presence:quiz:quiz-1')!;
+    channel.emit('sync');
+
+    expect(onSync1).not.toHaveBeenCalled();
+    expect(onSync2).toHaveBeenCalledTimes(1);
+  });
+
+  it('tears down the channel once the grace period elapses uncancelled', async () => {
+    const { client, channelsByName } = createMockClient();
+    const tracker = new SupabasePresenceTracker(client);
+
+    const unsubscribe = tracker.subscribe('quiz-1', 'player-1', {});
+    unsubscribe();
+
+    const channel = channelsByName.get('presence:quiz:quiz-1')!;
+    expect(channel.untrack).not.toHaveBeenCalled();
+    expect(channel.unsubscribe).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    expect(channel.untrack).toHaveBeenCalledTimes(1);
+    expect(channel.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call channel.untrack/unsubscribe if resubscribed before the grace period elapses', async () => {
+    const { client, channelsByName } = createMockClient();
+    const tracker = new SupabasePresenceTracker(client);
+
+    const unsubscribe1 = tracker.subscribe('quiz-1', 'player-1', {});
+    unsubscribe1();
+
+    tracker.subscribe('quiz-1', 'player-1', {});
+
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    const channel = channelsByName.get('presence:quiz:quiz-1')!;
+    expect(channel.untrack).not.toHaveBeenCalled();
+    expect(channel.unsubscribe).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Two related, sequentially-discovered bugs that together mean the presence heartbeat mechanism (fixed in PR #58) never actually ran in production:

- **`PresenceTrackerProvider` was never mounted anywhere in `src/app`.** `usePresenceTracker()` always returned `null`, so `usePresence`'s mount effect never started the heartbeat controller for any player, ever. Fixed by mounting it in `AppProviders`, mirroring the sibling `RealtimeClientProvider`, and hardening `usePresenceTracker()` to fail loud (throw) instead of silently returning `null`, matching `useRealtimeClient()`'s existing pattern.
- **Fixing the above exposed a second, 100%-reproducible crash**: `SupabasePresenceTracker.subscribe()` threw `"cannot add presence callbacks ... after subscribe()"` on any component remount fast enough that the previous async cleanup hadn't finished (observed via React Strict Mode's dev double-invoke). Traced into `@supabase/realtime-js`'s source and confirmed its client dedupes channels by topic internally, releasing only via an async close handshake — so a naive "delete from map first" fix wasn't sufficient. Fixed by keeping the channel alive for a 3s grace period after unsubscribe, canceling deferred teardown on reuse, and routing presence handlers through a mutable object so a reused channel never needs `.on()` called twice (mirrors the already-working pattern in `broadcast-channel-pool.ts`).

Also added real unit tests for `SupabasePresenceTracker` itself — the existing test file only tested a hand-written fake, never the real class, which is part of why this bug shipped unnoticed.

## Test plan

- [x] `yarn test` — 459 passed, 1 skipped, no regressions
- [x] `yarn lint` — 0 errors
- [x] `yarn build` — succeeds
- [x] Per-task and final whole-branch reviews completed (subagent-driven-development), no Critical/Important findings
- [x] Manual Playwright verification: joining no longer crashes, `/presence` heartbeat POSTs fire, simulated failure shows "Connection lost. Trying to reconnect...", recovery confirmed (toast + host dashboard shows player Connected/Last seen just now)