### PR TITLE
fix: wire up leaderboard:update realtime subscription on host dashboard

### DIFF
--- a/src/hooks/use-host-quiz-state.ts
+++ b/src/hooks/use-host-quiz-state.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { QuizDTO } from '@application/dtos/quiz.dto';
+import type { LeaderboardEntryDTO, QuizDTO } from '@application/dtos/quiz.dto';
 import type { RoundSummaryDTO } from '@application/dtos/round-summary.dto';
 import { useRealtimeClient } from '@hooks/use-realtime-client';
 
@@ -77,6 +77,20 @@ export const useHostQuizState = ({
         queryClient.setQueryData(hostQuizQueryKey(quizId), updatedState);
       }
     );
+
+    return unsubscribe;
+  }, [channelName, queryClient, quizId, realtimeClient]);
+
+  useEffect(() => {
+    const unsubscribe = realtimeClient.subscribe<{
+      leaderboard: LeaderboardEntryDTO[];
+    }>(channelName, 'leaderboard:update', ({ leaderboard }) => {
+      queryClient.setQueryData(
+        hostQuizQueryKey(quizId),
+        (current: QuizDTO | undefined) =>
+          current ? { ...current, leaderboard } : current
+      );
+    });
 
     return unsubscribe;
   }, [channelName, queryClient, quizId, realtimeClient]);


### PR DESCRIPTION
## Summary

- The host dashboard broadcasts a `leaderboard:update` event (`src/infrastructure/realtime/broadcast-leaderboard.ts`) on channel `quiz:{quizId}`, but nothing on the host side ever subscribed to it — the Leaderboard panel only updated on the next 5s poll instead of in real time.
- Adds a `useEffect` in `use-host-quiz-state.ts` that subscribes to `leaderboard:update` and merges the new leaderboard into the cached `QuizDTO` via `queryClient.setQueryData`.

## Test plan

- [x] `yarn test use-host-quiz-state leaderboard` — passing
- [x] `yarn lint` — clean (pre-existing unrelated warnings only)
- [x] Manual Playwright verification: submitted an answer as a player, immediately switched to the host tab, confirmed the Leaderboard panel updated without waiting for the 5s poll